### PR TITLE
Make ClusterAutoscaler resource a singleton

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -30,6 +30,10 @@ func getConfig() *operator.Config {
 		config.ClusterAutoscalerName = caName
 	}
 
+	if caImage, ok := os.LookupEnv("CLUSTER_AUTOSCALER_IMAGE"); ok {
+		config.ClusterAutoscalerImage = caImage
+	}
+
 	return config
 }
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -34,6 +34,10 @@ func getConfig() *operator.Config {
 		config.ClusterAutoscalerImage = caImage
 	}
 
+	if caNamespace, ok := os.LookupEnv("CLUSTER_AUTOSCALER_NAMESPACE"); ok {
+		config.ClusterAutoscalerNamespace = caNamespace
+	}
+
 	return config
 }
 

--- a/examples/clusterautoscaler.yaml
+++ b/examples/clusterautoscaler.yaml
@@ -2,7 +2,7 @@
 apiVersion: "autoscaling.openshift.io/v1alpha1"
 kind: "ClusterAutoscaler"
 metadata:
-  name: "example"
+  name: "default"
 spec:
   podPriorityThreshold: -10
   resourceLimits:

--- a/install/0000_50_cluster-autoscaler-operator_01_clusterautoscaler.crd.yaml
+++ b/install/0000_50_cluster-autoscaler-operator_01_clusterautoscaler.crd.yaml
@@ -11,5 +11,5 @@ spec:
     listKind: ClusterAutoscalerList
     plural: clusterautoscalers
     singular: clusterautoscaler
-  scope: Namespaced
+  scope: Cluster
   version: v1alpha1

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,16 +1,17 @@
 package controller
 
 import (
+	"github.com/openshift/cluster-autoscaler-operator/pkg/operator"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(manager.Manager) error
+var AddToManagerFuncs []func(manager.Manager, *operator.Config) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager) error {
+func AddToManager(m manager.Manager, c *operator.Config) error {
 	for _, f := range AddToManagerFuncs {
-		if err := f(m); err != nil {
+		if err := f(m, c); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/machineautoscaler/machineautoscaler_controller.go
+++ b/pkg/controller/machineautoscaler/machineautoscaler_controller.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/glog"
 	autoscalingv1alpha1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1alpha1"
+	"github.com/openshift/cluster-autoscaler-operator/pkg/operator"
 	"github.com/openshift/cluster-autoscaler-operator/pkg/util"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,8 +41,8 @@ var SupportedTargetGVKs = []schema.GroupVersionKind{
 // Add creates a new MachineAutoscaler Controller and adds it to the
 // Manager. The Manager will set fields on the Controller and Start it when the
 // Manager is Started.
-func Add(mgr manager.Manager) error {
-	return add(mgr, newReconciler(mgr))
+func Add(mgr manager.Manager, cfg *operator.Config) error {
+	return add(mgr, cfg, newReconciler(mgr))
 }
 
 // newReconciler returns a new reconcile.Reconciler
@@ -53,7 +54,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
+func add(mgr manager.Manager, cfg *operator.Config, r reconcile.Reconciler) error {
 	// Create a new controller
 	c, err := controller.New("machineautoscaler-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -4,6 +4,18 @@ const (
 	// DefaultClusterAutoscalerName is the default ClusterAutoscaler
 	// object watched by the operator.
 	DefaultClusterAutoscalerName = "default"
+
+	// DefaultClusterAutoscalerImage is the default image used in
+	// ClusterAutoscaler deployments.
+	//
+	// TODO(bison): This should obviously be moved to the official
+	// namespace once cluster-api support is merged in the OpenShift
+	// fork.
+	DefaultClusterAutoscalerImage = "quay.io/bison/cluster-autoscaler:a554b4f5"
+
+	// DefaultClusterAutoscalerReplicas is the default number of
+	// replicas in ClusterAutoscaler deployments.
+	DefaultClusterAutoscalerReplicas = 1
 )
 
 // Config represents the runtime configuration for the operator.
@@ -11,11 +23,21 @@ type Config struct {
 	// ClusterAutoscalerName is the name of the ClusterAutoscaler
 	// resource that will be watched by the operator.
 	ClusterAutoscalerName string
+
+	// ClusterAutoscalerImage is the image to be used in
+	// ClusterAutoscaler deployments.
+	ClusterAutoscalerImage string
+
+	// ClusterAutoscalerReplicas is the number of replicas to be
+	// configured in ClusterAutoscaler deployments.
+	ClusterAutoscalerReplicas int32
 }
 
 // NewConfig returns a new Config object with defaults set.
 func NewConfig() *Config {
 	return &Config{
-		ClusterAutoscalerName: DefaultClusterAutoscalerName,
+		ClusterAutoscalerName:     DefaultClusterAutoscalerName,
+		ClusterAutoscalerImage:    DefaultClusterAutoscalerImage,
+		ClusterAutoscalerReplicas: DefaultClusterAutoscalerReplicas,
 	}
 }

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -1,6 +1,10 @@
 package operator
 
 const (
+	// DefaultClusterAutoscalerNamespace is the default namespace for
+	// cluster-autoscaler deployments.
+	DefaultClusterAutoscalerNamespace = "openshift-cluster-autoscaler"
+
 	// DefaultClusterAutoscalerName is the default ClusterAutoscaler
 	// object watched by the operator.
 	DefaultClusterAutoscalerName = "default"
@@ -20,6 +24,10 @@ const (
 
 // Config represents the runtime configuration for the operator.
 type Config struct {
+	// ClusterAutoscalerNamespace is the namespace in which
+	// cluster-autoscaler deployments will be created.
+	ClusterAutoscalerNamespace string
+
 	// ClusterAutoscalerName is the name of the ClusterAutoscaler
 	// resource that will be watched by the operator.
 	ClusterAutoscalerName string
@@ -36,8 +44,9 @@ type Config struct {
 // NewConfig returns a new Config object with defaults set.
 func NewConfig() *Config {
 	return &Config{
-		ClusterAutoscalerName:     DefaultClusterAutoscalerName,
-		ClusterAutoscalerImage:    DefaultClusterAutoscalerImage,
-		ClusterAutoscalerReplicas: DefaultClusterAutoscalerReplicas,
+		ClusterAutoscalerNamespace: DefaultClusterAutoscalerNamespace,
+		ClusterAutoscalerName:      DefaultClusterAutoscalerName,
+		ClusterAutoscalerImage:     DefaultClusterAutoscalerImage,
+		ClusterAutoscalerReplicas:  DefaultClusterAutoscalerReplicas,
 	}
 }

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -1,0 +1,21 @@
+package operator
+
+const (
+	// DefaultClusterAutoscalerName is the default ClusterAutoscaler
+	// object watched by the operator.
+	DefaultClusterAutoscalerName = "default"
+)
+
+// Config represents the runtime configuration for the operator.
+type Config struct {
+	// ClusterAutoscalerName is the name of the ClusterAutoscaler
+	// resource that will be watched by the operator.
+	ClusterAutoscalerName string
+}
+
+// NewConfig returns a new Config object with defaults set.
+func NewConfig() *Config {
+	return &Config{
+		ClusterAutoscalerName: DefaultClusterAutoscalerName,
+	}
+}


### PR DESCRIPTION
This makes the ClusterAutoscaler resource a singleton. The CRD becomes cluster-scoped and the operator only watches a single instance. The name of the instance to watch is configurable at runtime.

It also allows for overriding the cluster-autoscaler image via an environment variable.