### PR TITLE
Add initial unit-test suite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,12 @@ WORKDIR /go/src/github.com/openshift/cluster-autoscaler-operator
 # the cluster-autoscaler-operator directory.
 # e.g. docker build -t <tag> -f <this_Dockerfile> <path_to_cluster-autoscaler-operator>
 COPY . .
-RUN GOPATH=/go CGO_ENABLED=0 go build -o /go/bin/cluster-autoscaler-operator ./cmd/manager
+
+ENV NO_DOCKER=1
+ENV GOPATH=/go
+ENV BUILD_DEST=/go/bin/cluster-autoscaler-operator
+
+RUN unset VERSION && make build
 
 # Final container
 FROM openshift/origin-base

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 DBG         ?= 0
+PROJECT     ?= cluster-autoscaler-operator
+ORG_PATH    ?= github.com/openshift
+REPO_PATH   ?= $(ORG_PATH)/$(PROJECT)
 VERSION     ?= $(shell git describe --always --abbrev=7)
+LD_FLAGS    ?= -X $(REPO_PATH)/version.Version=$(VERSION)
+BUILD_DEST  ?= bin/cluster-autoscaler-operator
 MUTABLE_TAG ?= latest
 IMAGE        = origin-cluster-autoscaler-operator
 
@@ -15,7 +20,7 @@ ifeq ($(NO_DOCKER), 1)
   DOCKER_CMD =
   IMAGE_BUILD_CMD = imagebuilder
 else
-  DOCKER_CMD := docker run --rm -v "$(PWD)":/go/src/github.com/openshift/cluster-autoscaler-operator:Z -w /go/src/github.com/openshift/cluster-autoscaler-operator openshift/origin-release:golang-1.10
+  DOCKER_CMD := docker run --rm -v "$(PWD):/go/src/$(REPO_PATH):Z" -w "/go/src/$(REPO_PATH)" openshift/origin-release:golang-1.10
   IMAGE_BUILD_CMD = docker build
 endif
 
@@ -30,7 +35,7 @@ depend-update:
 
 .PHONY: build
 build: ## build binaries
-	$(DOCKER_CMD) go build $(GOGCFLAGS) -o bin/cluster-autoscaler-operator github.com/openshift/cluster-autoscaler-operator/cmd/manager
+	$(DOCKER_CMD) go build $(GOGCFLAGS) -ldflags "$(LD_FLAGS)" -o "$(BUILD_DEST)" "$(REPO_PATH)/cmd/manager"
 
 .PHONY: images
 images: ## Create images

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/cluster-autoscaler-operator/pkg/apis"
 	"github.com/openshift/cluster-autoscaler-operator/pkg/controller"
 	"github.com/openshift/cluster-autoscaler-operator/pkg/operator"
+	"github.com/openshift/cluster-autoscaler-operator/version"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -21,6 +22,7 @@ func printVersion() {
 	glog.Infof("Go Version: %s", runtime.Version())
 	glog.Infof("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
 	glog.Infof("operator-sdk Version: %v", sdkVersion.Version)
+	glog.Infof("cluster-autoscaler-operator Version: %v", version.Version)
 }
 
 func getConfig() *operator.Config {

--- a/pkg/controller/clusterautoscaler/clusterautoscaler.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler.go
@@ -2,7 +2,6 @@ package clusterautoscaler
 
 import (
 	"fmt"
-	"strconv"
 
 	v1alpha1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1alpha1"
 )
@@ -17,8 +16,8 @@ func (a AutoscalerArg) String() string {
 }
 
 // Value returns the argument with the given value set.
-func (a AutoscalerArg) Value(v string) string {
-	return fmt.Sprintf("%s=%s", a.String(), v)
+func (a AutoscalerArg) Value(v interface{}) string {
+	return fmt.Sprintf("%s=%v", a.String(), v)
 }
 
 // Range returns the argument with the given numerical range set.
@@ -53,7 +52,7 @@ const (
 // to the cluster-autoscaler corresponding to the values in the given
 // ClusterAutoscaler resource.
 func AutoscalerArgs(ca *v1alpha1.ClusterAutoscaler, namespace string) []string {
-	spec := &ca.Spec
+	s := &ca.Spec
 
 	args := []string{
 		LogToStderrArg.String(),
@@ -62,21 +61,21 @@ func AutoscalerArgs(ca *v1alpha1.ClusterAutoscaler, namespace string) []string {
 	}
 
 	if ca.Spec.MaxPodGracePeriod != nil {
-		v := strconv.Itoa(int(*spec.MaxPodGracePeriod))
-		args = append(args, MaxGracefulTerminationSecArg.Value(v))
+		v := MaxGracefulTerminationSecArg.Value(*s.MaxPodGracePeriod)
+		args = append(args, v)
 	}
 
 	if ca.Spec.PodPriorityThreshold != nil {
-		v := strconv.Itoa(int(*spec.PodPriorityThreshold))
-		args = append(args, ExpendablePodsPriorityCutoffArg.Value(v))
+		v := ExpendablePodsPriorityCutoffArg.Value(*s.PodPriorityThreshold)
+		args = append(args, v)
 	}
 
 	if ca.Spec.ResourceLimits != nil {
-		args = append(args, ResourceArgs(spec.ResourceLimits)...)
+		args = append(args, ResourceArgs(s.ResourceLimits)...)
 	}
 
 	if ca.Spec.ScaleDown != nil {
-		args = append(args, ScaleDownArgs(spec.ScaleDown)...)
+		args = append(args, ScaleDownArgs(s.ScaleDown)...)
 	}
 
 	return args
@@ -107,8 +106,7 @@ func ResourceArgs(rl *v1alpha1.ResourceLimits) []string {
 	args := []string{}
 
 	if rl.MaxNodesTotal != nil {
-		v := strconv.Itoa(int(*rl.MaxNodesTotal))
-		args = append(args, MaxNodesTotalArg.Value(v))
+		args = append(args, MaxNodesTotalArg.Value(*rl.MaxNodesTotal))
 	}
 
 	if rl.Cores != nil {

--- a/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
@@ -292,7 +292,7 @@ func (r *Reconciler) AutoscalerDeployment(ca *autoscalingv1alpha1.ClusterAutosca
 // AutoscalerPodSpec returns the expected podSpec for the deployment belonging
 // to the given ClusterAutoscaler.
 func (r *Reconciler) AutoscalerPodSpec(ca *autoscalingv1alpha1.ClusterAutoscaler) *corev1.PodSpec {
-	args := AutoscalerArgs(ca)
+	args := AutoscalerArgs(ca, r.caNamespace)
 
 	spec := &corev1.PodSpec{
 		ServiceAccountName: caServiceAccount,

--- a/pkg/controller/clusterautoscaler/clusterautoscaler_test.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_test.go
@@ -1,0 +1,92 @@
+package clusterautoscaler
+
+import (
+	"testing"
+
+	autoscalingv1alpha1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	NvidiaGPU     = "nvidia.com/gpu"
+	TestNamespace = "test"
+)
+
+var (
+	PodPriorityThreshold int32 = -10
+	MaxPodGracePeriod    int32 = 60
+	MaxNodesTotal        int32 = 100
+	CoresMin             int32 = 16
+	CoresMax             int32 = 32
+	MemoryMin            int32 = 32
+	MemoryMax            int32 = 64
+	NvidiaGPUMin         int32 = 4
+	NvidiaGPUMax         int32 = 8
+)
+
+func NewClusterAutoscaler() *autoscalingv1alpha1.ClusterAutoscaler {
+	// TODO: Maybe just deserialize this from a YAML file?
+	return &autoscalingv1alpha1.ClusterAutoscaler{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterAutoscaler",
+			APIVersion: "autoscaling.openshift.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: TestNamespace,
+		},
+		Spec: autoscalingv1alpha1.ClusterAutoscalerSpec{
+			MaxPodGracePeriod:    &MaxPodGracePeriod,
+			PodPriorityThreshold: &PodPriorityThreshold,
+			ResourceLimits: &autoscalingv1alpha1.ResourceLimits{
+				MaxNodesTotal: &MaxNodesTotal,
+				Cores: &autoscalingv1alpha1.ResourceRange{
+					Min: CoresMin,
+					Max: CoresMax,
+				},
+				Memory: &autoscalingv1alpha1.ResourceRange{
+					Min: MemoryMin,
+					Max: MemoryMax,
+				},
+				GPUS: []autoscalingv1alpha1.GPULimit{
+					{
+						Type: NvidiaGPU,
+						ResourceRange: autoscalingv1alpha1.ResourceRange{
+							Min: NvidiaGPUMin,
+							Max: NvidiaGPUMax,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func includeString(list []string, item string) bool {
+	for i := range list {
+		if list[i] == item {
+			return true
+		}
+	}
+
+	return false
+}
+
+func TestAutoscalerArgs(t *testing.T) {
+	ca := NewClusterAutoscaler()
+
+	args := AutoscalerArgs(ca, TestNamespace)
+
+	expected := []string{
+		ExpendablePodsPriorityCutoffArg.Value(PodPriorityThreshold),
+		MaxGracefulTerminationSecArg.Value(MaxPodGracePeriod),
+		MaxNodesTotalArg.Value(MaxNodesTotal),
+		CoresTotalArg.Range(int(CoresMin), int(CoresMax)),
+	}
+
+	for _, e := range expected {
+		if !includeString(args, e) {
+			t.Fatalf("missing arg: %s", e)
+		}
+	}
+}

--- a/pkg/controller/machineautoscaler/machinetarget_test.go
+++ b/pkg/controller/machineautoscaler/machinetarget_test.go
@@ -1,0 +1,140 @@
+package machineautoscaler
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// TestObject is a fake Kubernetes object used as a reference in a
+// MachineTarget objects in the test suite.
+type TestObject struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+}
+
+// NewTarget returns a new MachineTarget referencing an TestObject.
+func NewTarget() *MachineTarget {
+	obj := &TestObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		panic(err)
+	}
+
+	return &MachineTarget{
+		Unstructured: unstructured.Unstructured{
+			Object: u,
+		},
+	}
+}
+
+func TestNeedsUpdate(t *testing.T) {
+	target := NewTarget()
+	target.SetLimits(4, 6)
+
+	// Different min and max.
+	if !target.NeedsUpdate(2, 4) {
+		t.Fatal("target should need update")
+	}
+
+	// Same min and max.
+	if target.NeedsUpdate(4, 6) {
+		t.Fatal("target should not need update")
+	}
+
+	target.SetLabels(map[string]string{
+		minSizeLabel: "not-an-int",
+		maxSizeLabel: "not-an-int",
+	})
+
+	// Error parsing values.
+	if !target.NeedsUpdate(1, 2) {
+		t.Fatal("target should need update")
+	}
+}
+
+func TestSetLimits(t *testing.T) {
+	target := NewTarget()
+	expectedMin, expectedMax := 2, 4
+
+	target.SetLimits(expectedMin, expectedMax)
+	min, max, err := target.GetLimits()
+	if err != nil {
+		t.Fatalf("error getting limits: %v", err)
+	}
+
+	if min != expectedMin || max != expectedMax {
+		t.Fatalf("got %d-%d, want %d-%d",
+			min, max, expectedMin, expectedMax)
+	}
+}
+
+func TestGetLimits(t *testing.T) {
+	target := NewTarget()
+
+	// No labels.
+	_, _, err := target.GetLimits()
+	if err != ErrTargetMissingLabels {
+		t.Fatal("expected missing labels error")
+	}
+
+	// Set bad min label.
+	target.SetLabels(map[string]string{
+		minSizeLabel: "not-an-int",
+		maxSizeLabel: "4",
+	})
+
+	_, _, err = target.GetLimits()
+	if err == nil {
+		t.Fatal("expected bad label error")
+	}
+
+	// Set bad max label.
+	target.SetLabels(map[string]string{
+		minSizeLabel: "2",
+		maxSizeLabel: "not-an-int",
+	})
+
+	_, _, err = target.GetLimits()
+	if err == nil {
+		t.Fatal("expected bad label error")
+	}
+
+	// Set correct labels.
+	expectedMin, expectedMax := 2, 4
+	target.SetLimits(expectedMin, expectedMax)
+
+	min, max, err := target.GetLimits()
+	if err != nil {
+		t.Fatal("error getting limits")
+	}
+
+	if min != 2 || max != 4 {
+		t.Fatalf("got %d-%d, want %d-%d",
+			min, max, expectedMin, expectedMax)
+	}
+}
+
+func TestRemoveLimits(t *testing.T) {
+	target := NewTarget()
+
+	target.SetLimits(2, 4)
+	target.RemoveLimits()
+
+	labels := target.GetLabels()
+
+	_, minOK := labels[minSizeLabel]
+	_, maxOK := labels[maxSizeLabel]
+
+	if minOK || maxOK {
+		t.Fatal("found labels after removal")
+	}
+}

--- a/pkg/operator/config_test.go
+++ b/pkg/operator/config_test.go
@@ -1,0 +1,14 @@
+package operator
+
+import "testing"
+
+func TestNewConfig(t *testing.T) {
+	config := NewConfig()
+	if config == nil {
+		t.Fatal("got a nil config object")
+	}
+
+	if config.ClusterAutoscalerNamespace != DefaultClusterAutoscalerNamespace {
+		t.Fatal("missing default for ClusterAutoscalerNamespace")
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -2,11 +2,13 @@ package util
 
 // FilterString removes any instances of the needle from haystack.
 func FilterString(haystack []string, needle string) []string {
-	for i := range haystack {
-		if haystack[i] == needle {
-			haystack = append(haystack[:i], haystack[i+1:]...)
+	newSlice := haystack[:0] // Share the backing array.
+
+	for _, x := range haystack {
+		if x != needle {
+			newSlice = append(newSlice, x)
 		}
 	}
 
-	return haystack
+	return newSlice
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,43 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+var filterStringTests = []struct {
+	label    string
+	needle   string
+	haystack []string
+	output   []string
+}{
+	{
+		label:    "single instance",
+		needle:   "foo",
+		haystack: []string{"foo", "bar", "baz"},
+		output:   []string{"bar", "baz"},
+	},
+	{
+		label:    "multiple instances",
+		needle:   "foo",
+		haystack: []string{"foo", "bar", "foo"},
+		output:   []string{"bar"},
+	},
+	{
+		label:    "zero instances",
+		needle:   "buzz",
+		haystack: []string{"foo", "bar", "foo"},
+		output:   []string{"foo", "bar", "foo"},
+	},
+}
+
+func TestFilterString(t *testing.T) {
+	for _, tt := range filterStringTests {
+		t.Run(tt.label, func(t *testing.T) {
+			got := FilterString(tt.haystack, tt.needle)
+			if !reflect.DeepEqual(got, tt.output) {
+				t.Errorf("got %q, want %q", got, tt.output)
+			}
+		})
+	}
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,7 @@
 package version
 
 var (
-	Version = "0.0.1"
+	// Version is the current version of the operator.  The actual
+	// value will be set by the build scripts.
+	Version = "not-built-properly"
 )


### PR DESCRIPTION
This adds the start of a unit-test suite. It also sets version information at build time, and adds a type to help with generating cluster-autoscaler arguments.