### PR TITLE
Deploy to correct namespace

### DIFF
--- a/examples/clusterautoscaler.yaml
+++ b/examples/clusterautoscaler.yaml
@@ -6,16 +6,16 @@ metadata:
 spec:
   podPriorityThreshold: -10
   resourceLimits:
-    maxNodesTotal: 100
+    maxNodesTotal: 24
     cores:
       min: 8
-      max: 64
+      max: 128
     memory:
       min: 4
-      max: 32
+      max: 256
     gpus:
       - type: nvidia.com/gpu
-        min: 2
+        min: 0
         max: 16
       - type: amd.com/gpu
         min: 0

--- a/examples/machineautoscaler.yaml
+++ b/examples/machineautoscaler.yaml
@@ -2,10 +2,11 @@
 apiVersion: "autoscaling.openshift.io/v1alpha1"
 kind: "MachineAutoscaler"
 metadata:
-  name: "example"
+  name: "worker-us-east-1a"
+  namespace: "openshift-cluster-api"
 spec:
-  minReplicas: 3
-  maxReplicas: 6
+  minReplicas: 1
+  maxReplicas: 12
   scaleTargetRef:
     apiVersion: cluster.k8s.io/v1alpha1
     kind: MachineSet

--- a/install/0000_50_cluster-autoscaler-operator_00_namespace.yaml
+++ b/install/0000_50_cluster-autoscaler-operator_00_namespace.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-cluster-autoscaler
+  name: openshift-cluster-api
   labels:
-    name: openshift-cluster-autoscaler
+    name: openshift-cluster-api
     openshift.io/run-level: "1"

--- a/install/0000_50_cluster-autoscaler-operator_03_rbac.yaml
+++ b/install/0000_50_cluster-autoscaler-operator_03_rbac.yaml
@@ -3,7 +3,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: cluster-autoscaler-operator
-  namespace: openshift-cluster-autoscaler
+  namespace: openshift-cluster-api
 rules:
 - apiGroups:
   - autoscaling.openshift.io
@@ -38,11 +38,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: cluster-autoscaler-operator
-  namespace: openshift-cluster-autoscaler
+  namespace: openshift-cluster-api
 subjects:
 - kind: ServiceAccount
   name: cluster-autoscaler-operator
-  namespace: openshift-cluster-autoscaler
+  namespace: openshift-cluster-api
 roleRef:
   kind: Role
   name: cluster-autoscaler-operator
@@ -56,7 +56,7 @@ metadata:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
-  namespace: openshift-cluster-autoscaler
+  namespace: openshift-cluster-api
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -110,7 +110,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cluster-autoscaler
-  namespace: openshift-cluster-autoscaler
+  namespace: openshift-cluster-api
   labels:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
@@ -138,14 +138,14 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: cluster-autoscaler
-    namespace: openshift-cluster-autoscaler
+    namespace: openshift-cluster-api
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cluster-autoscaler
-  namespace: openshift-cluster-autoscaler
+  namespace: openshift-cluster-api
   labels:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
@@ -156,4 +156,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: cluster-autoscaler
-    namespace: openshift-cluster-autoscaler
+    namespace: openshift-cluster-api

--- a/install/0000_50_cluster-autoscaler-operator_03_rbac.yaml
+++ b/install/0000_50_cluster-autoscaler-operator_03_rbac.yaml
@@ -96,14 +96,14 @@ rules:
   resources: ["poddisruptionbudgets"]
   verbs: ["watch","list"]
 - apiGroups: ["apps"]
-  resources: ["statefulsets"]
+  resources: ["statefulsets","replicasets","daemonsets"]
   verbs: ["watch","list","get"]
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
   verbs: ["watch","list","get"]
 - apiGroups: ["cluster.k8s.io"]
   resources: ["machinesets", "machines"]
-  verbs: ["watch","list","get"]
+  verbs: ["watch","list","get","update"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
@@ -300,7 +300,7 @@ func (r *Reconciler) AutoscalerPodSpec(ca *autoscalingv1alpha1.ClusterAutoscaler
 			{
 				Name:    "cluster-autoscaler",
 				Image:   r.caImage,
-				Command: []string{"/cluster-autoscaler"},
+				Command: []string{"cluster-autoscaler"},
 				Args:    args,
 			},
 		},

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -3,7 +3,7 @@ package operator
 const (
 	// DefaultClusterAutoscalerNamespace is the default namespace for
 	// cluster-autoscaler deployments.
-	DefaultClusterAutoscalerNamespace = "openshift-cluster-autoscaler"
+	DefaultClusterAutoscalerNamespace = "openshift-cluster-api"
 
 	// DefaultClusterAutoscalerName is the default ClusterAutoscaler
 	// object watched by the operator.

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -11,11 +11,7 @@ const (
 
 	// DefaultClusterAutoscalerImage is the default image used in
 	// ClusterAutoscaler deployments.
-	//
-	// TODO(bison): This should obviously be moved to the official
-	// namespace once cluster-api support is merged in the OpenShift
-	// fork.
-	DefaultClusterAutoscalerImage = "quay.io/bison/cluster-autoscaler:a554b4f5"
+	DefaultClusterAutoscalerImage = "quay.io/openshift/origin-cluster-autoscaler:v4.0"
 
 	// DefaultClusterAutoscalerReplicas is the default number of
 	// replicas in ClusterAutoscaler deployments.


### PR DESCRIPTION
We decided on deploying this to the `openshift-cluster-api` namespace along with other components for now. This updates the namespace and uses the actual OpenShift image for the autoscaler.