### PR TITLE
Use annotations instead of labels for min and max

### DIFF
--- a/pkg/controller/machineautoscaler/machineautoscaler_controller.go
+++ b/pkg/controller/machineautoscaler/machineautoscaler_controller.go
@@ -21,11 +21,11 @@ import (
 
 const (
 	// MachineTargetFinalizer is the finalizer added to MachineAutoscaler
-	// instances to allow for cleanup of labels on target resources.
+	// instances to allow for cleanup of annotations on target resources.
 	MachineTargetFinalizer = "machinetarget.autoscaling.openshift.io"
 
-	minSizeLabel = "sigs.k8s.io/cluster-api-autoscaler-node-group-min-size"
-	maxSizeLabel = "sigs.k8s.io/cluster-api-autoscaler-node-group-max-size"
+	minSizeAnnotation = "sigs.k8s.io/cluster-api-autoscaler-node-group-min-size"
+	maxSizeAnnotation = "sigs.k8s.io/cluster-api-autoscaler-node-group-max-size"
 )
 
 // ErrUnsupportedTarget is the error returned when a target references an object
@@ -175,9 +175,9 @@ func (r *Reconciler) GetTarget(ma *autoscalingv1alpha1.MachineAutoscaler) (*Mach
 	return target, nil
 }
 
-// UpdateTarget updates the min and max labels on the given target.
+// UpdateTarget updates the min and max annotations on the given target.
 func (r *Reconciler) UpdateTarget(target *MachineTarget, min, max int) error {
-	// Update the target object's labels if necessary.
+	// Update the target object's annotations if necessary.
 	if target.NeedsUpdate(min, max) {
 		target.SetLimits(min, max)
 	}

--- a/pkg/controller/machineautoscaler/machinetarget.go
+++ b/pkg/controller/machineautoscaler/machinetarget.go
@@ -8,9 +8,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// ErrTargetMissingLabels is the error returned when a target is
-// missing the min or max labels.
-var ErrTargetMissingLabels = errors.New("missing min or max label")
+// ErrTargetMissingAnnotations is the error returned when a target is
+// missing the min or max annotations.
+var ErrTargetMissingAnnotations = errors.New("missing min or max annotation")
 
 // MachineTarget represents an unstructured target object for a
 // MachineAutoscaler, used to update metadata only.
@@ -33,50 +33,50 @@ func (mt *MachineTarget) NeedsUpdate(min, max int) bool {
 	return minDiff || maxDiff
 }
 
-// SetLimits sets the target's min and max labels.
+// SetLimits sets the target's min and max annotations.
 func (mt *MachineTarget) SetLimits(min, max int) {
-	labels := mt.GetLabels()
+	annotations := mt.GetAnnotations()
 
-	if labels == nil {
-		labels = make(map[string]string)
+	if annotations == nil {
+		annotations = make(map[string]string)
 	}
 
-	labels[minSizeLabel] = strconv.Itoa(min)
-	labels[maxSizeLabel] = strconv.Itoa(max)
+	annotations[minSizeAnnotation] = strconv.Itoa(min)
+	annotations[maxSizeAnnotation] = strconv.Itoa(max)
 
-	mt.SetLabels(labels)
+	mt.SetAnnotations(annotations)
 }
 
-// RemoveLimits removes the target's min and max labels.
+// RemoveLimits removes the target's min and max annotations.
 func (mt *MachineTarget) RemoveLimits() {
-	labels := mt.GetLabels()
+	annotations := mt.GetAnnotations()
 
-	delete(labels, minSizeLabel)
-	delete(labels, maxSizeLabel)
+	delete(annotations, minSizeAnnotation)
+	delete(annotations, maxSizeAnnotation)
 
-	mt.SetLabels(labels)
+	mt.SetAnnotations(annotations)
 }
 
 // GetLimits returns the target's min and max limits.  An error may be
-// returned if the label's contents could not be parsed as integers.
+// returned if the annotations's contents could not be parsed as ints.
 func (mt *MachineTarget) GetLimits() (min, max int, err error) {
-	labels := mt.GetLabels()
+	annotations := mt.GetAnnotations()
 
-	minString, minOK := labels[minSizeLabel]
-	maxString, maxOK := labels[maxSizeLabel]
+	minString, minOK := annotations[minSizeAnnotation]
+	maxString, maxOK := annotations[maxSizeAnnotation]
 
 	if !minOK || !maxOK {
-		return 0, 0, ErrTargetMissingLabels
+		return 0, 0, ErrTargetMissingAnnotations
 	}
 
 	min, err = strconv.Atoi(minString)
 	if err != nil {
-		return 0, 0, fmt.Errorf("bad min label: %s", minString)
+		return 0, 0, fmt.Errorf("bad min annotation: %s", minString)
 	}
 
 	max, err = strconv.Atoi(maxString)
 	if err != nil {
-		return 0, 0, fmt.Errorf("bad max label: %s", maxString)
+		return 0, 0, fmt.Errorf("bad max annotation: %s", maxString)
 	}
 
 	return min, max, nil

--- a/pkg/controller/machineautoscaler/machinetarget_test.go
+++ b/pkg/controller/machineautoscaler/machinetarget_test.go
@@ -50,9 +50,9 @@ func TestNeedsUpdate(t *testing.T) {
 		t.Fatal("target should not need update")
 	}
 
-	target.SetLabels(map[string]string{
-		minSizeLabel: "not-an-int",
-		maxSizeLabel: "not-an-int",
+	target.SetAnnotations(map[string]string{
+		minSizeAnnotation: "not-an-int",
+		maxSizeAnnotation: "not-an-int",
 	})
 
 	// Error parsing values.
@@ -80,35 +80,35 @@ func TestSetLimits(t *testing.T) {
 func TestGetLimits(t *testing.T) {
 	target := NewTarget()
 
-	// No labels.
+	// No annotations.
 	_, _, err := target.GetLimits()
-	if err != ErrTargetMissingLabels {
-		t.Fatal("expected missing labels error")
+	if err != ErrTargetMissingAnnotations {
+		t.Fatal("expected missing annotations error")
 	}
 
-	// Set bad min label.
-	target.SetLabels(map[string]string{
-		minSizeLabel: "not-an-int",
-		maxSizeLabel: "4",
+	// Set bad min annotation.
+	target.SetAnnotations(map[string]string{
+		minSizeAnnotation: "not-an-int",
+		maxSizeAnnotation: "4",
 	})
 
 	_, _, err = target.GetLimits()
 	if err == nil {
-		t.Fatal("expected bad label error")
+		t.Fatal("expected bad annotations error")
 	}
 
-	// Set bad max label.
-	target.SetLabels(map[string]string{
-		minSizeLabel: "2",
-		maxSizeLabel: "not-an-int",
+	// Set bad max annotation.
+	target.SetAnnotations(map[string]string{
+		minSizeAnnotation: "2",
+		maxSizeAnnotation: "not-an-int",
 	})
 
 	_, _, err = target.GetLimits()
 	if err == nil {
-		t.Fatal("expected bad label error")
+		t.Fatal("expected bad annotation error")
 	}
 
-	// Set correct labels.
+	// Set correct annotations.
 	expectedMin, expectedMax := 2, 4
 	target.SetLimits(expectedMin, expectedMax)
 
@@ -129,12 +129,12 @@ func TestRemoveLimits(t *testing.T) {
 	target.SetLimits(2, 4)
 	target.RemoveLimits()
 
-	labels := target.GetLabels()
+	annotations := target.GetAnnotations()
 
-	_, minOK := labels[minSizeLabel]
-	_, maxOK := labels[maxSizeLabel]
+	_, minOK := annotations[minSizeAnnotation]
+	_, maxOK := annotations[maxSizeAnnotation]
 
 	if minOK || maxOK {
-		t.Fatal("found labels after removal")
+		t.Fatal("found annotations after removal")
 	}
 }


### PR DESCRIPTION
The cluster-autoscaler has moved to using annotations instead of
labels for the min and max sizes of a group.  This updates
MachineTarget resources to set the limits as annotations.

  https://github.com/openshift/kubernetes-autoscaler/pull/11

Note: This doesn't perform any kind of migration from labels to annotations. I don't think anyone is using this yet, or is even really using the cluster-api provider in the autoscaler, so it's probably not necessary. We could do it if we wanted though.