### PR TITLE
Add initial e2e test suite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,7 @@ ENV BUILD_DEST=/go/bin/cluster-autoscaler-operator
 RUN unset VERSION && make build
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder # /go/bin/cluster-autoscaler-operator /usr/bin/
+COPY --from=builder /go/bin/cluster-autoscaler-operator /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-autoscaler-operator/install /manifests
 CMD ["/usr/bin/cluster-autoscaler-operator"]
+LABEL io.openshift.release.operator true

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -6,5 +6,7 @@ ENV BUILD_DEST=/go/bin/cluster-autoscaler-operator
 RUN unset VERSION && make build
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
-COPY --from=builder # /go/bin/cluster-autoscaler-operator /usr/bin/
+COPY --from=builder /go/bin/cluster-autoscaler-operator /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-autoscaler-operator/install /manifests
 CMD ["/usr/bin/cluster-autoscaler-operator"]
+LABEL io.openshift.release.operator true

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,12 @@ push:
 check: fmt vet lint test ## Check your code
 
 .PHONY: test
-test: # Run unit test
+test: ## Run unit tests
 	$(DOCKER_CMD) go test -race -cover ./...
+
+.PHONY: test-e2e
+test-e2e: ## Run e2e tests
+	 go run ./test/e2e -alsologtostderr
 
 .PHONY: lint
 lint: ## Go lint your code

--- a/install/0000_50_cluster-autoscaler-operator_04_deployment.yaml
+++ b/install/0000_50_cluster-autoscaler-operator_04_deployment.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler-operator
+  namespace: openshift-cluster-api
+  labels:
+    k8s-app: cluster-autoscaler-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: cluster-autoscaler-operator
+  template:
+    metadata:
+      labels:
+        k8s-app: cluster-autoscaler-operator
+    spec:
+      containers:
+      - name: cluster-autoscaler-operator
+        image: docker.io/openshift/origin-cluster-autoscaler-operator:v4.0.0
+        command:
+        - cluster-autoscaler-operator
+        args:
+        - -alsologtostderr
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CLUSTER_AUTOSCALER_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          limits:
+            cpu: 20m
+            memory: 50Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"

--- a/install/image-references
+++ b/install/image-references
@@ -1,0 +1,8 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: cluster-autoscaler-operator
+    from:
+      kind: DockerImage
+      name: docker.io/openshift/origin-cluster-autoscaler-operator:v4.0

--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"flag"
+
+	"github.com/golang/glog"
+	"github.com/openshift/cluster-autoscaler-operator/pkg/apis"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+const (
+	namespace = "openshift-cluster-api"
+	caName    = "default"
+)
+
+var F *Framework
+
+type Framework struct {
+	Client client.Client
+}
+
+func newClient() error {
+	// Get a config to talk to the apiserver
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	client, err := client.New(cfg, client.Options{})
+	if err != nil {
+		return err
+	}
+
+	F = &Framework{Client: client}
+
+	return nil
+}
+
+func main() {
+	flag.Parse()
+
+	if err := apis.AddToScheme(scheme.Scheme); err != nil {
+		glog.Fatal(err)
+	}
+
+	if err := newClient(); err != nil {
+		glog.Fatal(err)
+	}
+
+	if err := runSuite(); err != nil {
+		glog.Fatal(err)
+	}
+}
+
+func runSuite() error {
+	if err := ExpectOperatorAvailable(); err != nil {
+		glog.Errorf("FAIL: ExpectOperatorAvailable: %v", err)
+		return err
+	}
+	glog.Info("PASS: ExpectOperatorAvailable")
+
+	if err := CreateClusterAutoscaler(); err != nil {
+		glog.Errorf("FAIL: CreateClusterAutoscaler: %v", err)
+		return err
+	}
+	glog.Info("PASS: CreateClusterAutoscaler")
+
+	if err := ExpectClusterAutoscalerAvailable(); err != nil {
+		glog.Errorf("FAIL: ExpectClusterAutoscalerAvailable: %v", err)
+		return err
+	}
+	glog.Info("PASS: ExpectClusterAutoscalerAvailable")
+
+	return nil
+}

--- a/test/e2e/operator_expectations.go
+++ b/test/e2e/operator_expectations.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"context"
+
+	"github.com/golang/glog"
+	autoscalingv1alpha1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1alpha1"
+	kappsapi "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+var (
+	PodPriorityThreshold int32 = -10
+	MaxPodGracePeriod    int32 = 60
+	MaxNodesTotal        int32 = 100
+	CoresMin             int32 = 16
+	CoresMax             int32 = 32
+	MemoryMin            int32 = 32
+	MemoryMax            int32 = 64
+	NvidiaGPUMin         int32 = 4
+	NvidiaGPUMax         int32 = 8
+)
+
+func CreateClusterAutoscaler() error {
+	ca := &autoscalingv1alpha1.ClusterAutoscaler{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterAutoscaler",
+			APIVersion: "autoscaling.openshift.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      caName,
+			Namespace: namespace,
+		},
+		Spec: autoscalingv1alpha1.ClusterAutoscalerSpec{
+			MaxPodGracePeriod:    &MaxPodGracePeriod,
+			PodPriorityThreshold: &PodPriorityThreshold,
+			ResourceLimits: &autoscalingv1alpha1.ResourceLimits{
+				MaxNodesTotal: &MaxNodesTotal,
+				Cores: &autoscalingv1alpha1.ResourceRange{
+					Min: CoresMin,
+					Max: CoresMax,
+				},
+				Memory: &autoscalingv1alpha1.ResourceRange{
+					Min: MemoryMin,
+					Max: MemoryMax,
+				},
+			},
+		},
+	}
+
+	return F.Client.Create(context.TODO(), ca)
+}
+
+func ExpectOperatorAvailable() error {
+	name := "cluster-autoscaler-operator"
+	key := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	d := &kappsapi.Deployment{}
+
+	err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		if err := F.Client.Get(context.TODO(), key, d); err != nil {
+			glog.Errorf("error querying api for Deployment object: %v, retrying...", err)
+			return false, nil
+		}
+		if d.Status.ReadyReplicas < 1 {
+			return false, nil
+		}
+		return true, nil
+	})
+	return err
+}
+
+func ExpectClusterAutoscalerAvailable() error {
+	name := fmt.Sprintf("cluster-autoscaler-%s", caName)
+	key := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	d := &kappsapi.Deployment{}
+
+	err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		if err := F.Client.Get(context.TODO(), key, d); err != nil {
+			glog.Errorf("error querying api for Deployment object: %v, retrying...", err)
+			return false, nil
+		}
+		if d.Status.ReadyReplicas < 1 {
+			return false, nil
+		}
+		return true, nil
+	})
+	return err
+}


### PR DESCRIPTION
This adds the first step towards e2e tests based on the recent work in the machine-api-operator. It also adds a deployment manifest and related bits to enable the operator in the CVO.