### PR TITLE
Run autoscaler pods on master nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ test: ## Run unit tests
 
 .PHONY: test-e2e
 test-e2e: ## Run e2e tests
-	 go run ./test/e2e -alsologtostderr
+	 go run ./test/e2e/*.go -alsologtostderr
 
 .PHONY: lint
 lint: ## Go lint your code

--- a/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
@@ -296,6 +296,9 @@ func (r *Reconciler) AutoscalerPodSpec(ca *autoscalingv1alpha1.ClusterAutoscaler
 
 	spec := &corev1.PodSpec{
 		ServiceAccountName: caServiceAccount,
+		NodeSelector: map[string]string{
+			"node-role.kubernetes.io/master": "",
+		},
 		Containers: []corev1.Container{
 			{
 				Name:    "cluster-autoscaler",
@@ -307,6 +310,12 @@ func (r *Reconciler) AutoscalerPodSpec(ca *autoscalingv1alpha1.ClusterAutoscaler
 		Tolerations: []corev1.Toleration{
 			{
 				Key:      "CriticalAddonsOnly",
+				Operator: corev1.TolerationOpExists,
+			},
+			{
+
+				Key:      "node-role.kubernetes.io/master",
+				Effect:   corev1.TaintEffectNoSchedule,
 				Operator: corev1.TolerationOpExists,
 			},
 		},


### PR DESCRIPTION
Adds the toleration and node selector to the autoscaler pod to schedule it on master nodes.

Fixes #18.