### PR TITLE
Add MachineDeployment as a supported target

### DIFF
--- a/pkg/controller/machineautoscaler/machineautoscaler_controller.go
+++ b/pkg/controller/machineautoscaler/machineautoscaler_controller.go
@@ -35,6 +35,7 @@ var ErrUnsupportedTarget = errors.New("unsupported MachineAutoscaler target")
 // a MachineAutocaler instance.
 var SupportedTargetGVKs = []schema.GroupVersionKind{
 	{Group: "cluster.k8s.io", Version: "v1alpha1", Kind: "MachineSet"},
+	{Group: "cluster.k8s.io", Version: "v1alpha1", Kind: "MachineDeployment"},
 }
 
 // NewReconciler returns a new Reconciler.


### PR DESCRIPTION
The use of the cluster-api is moving away from MachineSets directly to
higher level MachineDeployment resources.  This adds MachineDeployment
resources as an additional supported target type for MachineAutoscaler
objects.  MachineSets may be removed at some point.