### PR TITLE
Printer columns for machine autoscaler

### DIFF
--- a/install/0000_50_cluster-autoscaler-operator_02_machineautoscaler.crd.yaml
+++ b/install/0000_50_cluster-autoscaler-operator_02_machineautoscaler.crd.yaml
@@ -13,3 +13,23 @@ spec:
     singular: machineautoscaler
   scope: Namespaced
   version: v1alpha1
+  additionalPrinterColumns:
+  - JSONPath: .spec.scaleTargetRef.kind
+    name: Ref Kind
+    description: Kind of object scaled
+    type: string
+  - JSONPath: .spec.scaleTargetRef.name
+    name: Ref Name
+    description: Name of object scaled
+    type: string
+  - JSONPath: .spec.minReplicas
+    name: Min
+    description: Min number of replicas
+    type: integer
+  - JSONPath: .spec.maxReplicas
+    name: Max
+    description: Max number of replicas
+    type: integer
+  - JSONPath: .metadata.creationTimestamp    
+    name: Age
+    type: date  


### PR DESCRIPTION
Pretty print in CLI as follows:

```sh
oc get machineautoscalers --all-namespaces
NAMESPACE               NAME                         REF KIND     REF NAME                        MIN       MAX       AGE
openshift-cluster-api   autoscale-us-east-2a-96b87   MachineSet   commonsdemo-worker-us-east-2a   1         12        12m
```