### PR TITLE
Only run the autoscaler pod on Linux nodes

### DIFF
--- a/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
@@ -281,6 +281,7 @@ func (r *Reconciler) AutoscalerPodSpec(ca *autoscalingv1alpha1.ClusterAutoscaler
 		PriorityClassName:  caPriorityClassName,
 		NodeSelector: map[string]string{
 			"node-role.kubernetes.io/master": "",
+			"beta.kubernetes.io/os":          "linux",
 		},
 		Containers: []corev1.Container{
 			{


### PR DESCRIPTION
The autoscaler pod should be limited to Linux nodes.