### PR TITLE
Use correct cluster-autoscaler image reference

### DIFF
--- a/install/0000_50_cluster-autoscaler-operator_04_deployment.yaml
+++ b/install/0000_50_cluster-autoscaler-operator_04_deployment.yaml
@@ -32,6 +32,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: CLUSTER_AUTOSCALER_IMAGE
+          value: docker.io/openshift/origin-cluster-autoscaler:v4.0
         resources:
           limits:
             cpu: 20m

--- a/install/image-references
+++ b/install/image-references
@@ -6,3 +6,7 @@ spec:
     from:
       kind: DockerImage
       name: docker.io/openshift/origin-cluster-autoscaler-operator:v4.0
+  - name: cluster-autoscaler
+    from:
+      kind: DockerImage
+      name: docker.io/openshift/origin-cluster-autoscaler:v4.0


### PR DESCRIPTION
This pulls the autoscaler image into the release and uses that for deployments.