### PR TITLE
Properly validate MachineAutoscaler target references

### DIFF
--- a/pkg/controller/machineautoscaler/machineautoscaler_controller_test.go
+++ b/pkg/controller/machineautoscaler/machineautoscaler_controller_test.go
@@ -1,0 +1,58 @@
+package machineautoscaler
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+var validateReferenceTests = []struct {
+	label  string
+	expect bool
+	ref    *corev1.ObjectReference
+}{
+	{
+		label:  "nil reference",
+		expect: false,
+		ref:    nil,
+	},
+	{
+		label:  "no name",
+		expect: false,
+		ref:    &corev1.ObjectReference{},
+	},
+	{
+		label:  "unsupported gvk",
+		expect: false,
+		ref: &corev1.ObjectReference{
+			Name:       "test",
+			Kind:       "bad",
+			APIVersion: "bad",
+		},
+	},
+	{
+		label:  "valid reference",
+		expect: true,
+		ref: &corev1.ObjectReference{
+			Name:       "test",
+			Kind:       "MachineSet",
+			APIVersion: "cluster.k8s.io/v1alpha1",
+		},
+	},
+}
+
+func TestValidateReference(t *testing.T) {
+	for _, tt := range validateReferenceTests {
+		t.Run(tt.label, func(t *testing.T) {
+			valid, err := ValidateReference(tt.ref)
+
+			if !valid && err == nil {
+				t.Error("reference invalid, but no error returned")
+			}
+
+			if valid != tt.expect {
+				t.Errorf("got %t, want %t, err: %v", valid, tt.expect, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds validation to MachineAutoscaler target references.
Previously, if for example a reference had no name set, the dynamic
client would return a list and cause a panic.  This prevents fetching
invalid or unsupported target references.