### PR TITLE
Use the correct ServiceAccount for the operator

### DIFF
--- a/install/0000_50_cluster-autoscaler-operator_03_rbac.yaml
+++ b/install/0000_50_cluster-autoscaler-operator_03_rbac.yaml
@@ -1,4 +1,17 @@
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-autoscaler-operator
+rules:
+- apiGroups:
+  - autoscaling.openshift.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -32,6 +45,16 @@ rules:
   - statefulsets
   verbs:
   - "*"
+- apiGroups:
+  - cluster.k8s.io
+  resources:
+  - machinedeployments
+  - machinesets
+  verbs:
+  - watch
+  - list
+  - get
+  - update
 
 ---
 kind: RoleBinding
@@ -47,6 +70,27 @@ roleRef:
   kind: Role
   name: cluster-autoscaler-operator
   apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-autoscaler-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler-operator
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler-operator
+    namespace: openshift-cluster-api
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-autoscaler-operator
+  namespace: openshift-cluster-api
 
 ---
 apiVersion: v1

--- a/install/0000_50_cluster-autoscaler-operator_04_deployment.yaml
+++ b/install/0000_50_cluster-autoscaler-operator_04_deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         k8s-app: cluster-autoscaler-operator
     spec:
+      serviceAccountName: cluster-autoscaler-operator
       containers:
       - name: cluster-autoscaler-operator
         image: docker.io/openshift/origin-cluster-autoscaler-operator:v4.0


### PR DESCRIPTION
The role and binding were present in the CVO manifests, but the
actual ServiceAccount was missing.  This adds it, and configures the
operator deployment to use it.