### PR TITLE
Allow to configure --scale-down-unneeded-time

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/clusterautoscaler_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/clusterautoscaler_types.go
@@ -64,4 +64,5 @@ type ScaleDownConfig struct {
 	DelayAfterAdd     string `json:"delayAfterAdd"`
 	DelayAfterDelete  string `json:"delayAfterDelete"`
 	DelayAfterFailure string `json:"delayAfterFailure"`
+	UnneededTime      string `json:"unneededTime,omitempty"`
 }

--- a/pkg/controller/clusterautoscaler/clusterautoscaler.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler.go
@@ -42,6 +42,7 @@ const (
 	ScaleDownDelayAfterAddArg       AutoscalerArg = "--scale-down-delay-after-add"
 	ScaleDownDelayAfterDeleteArg    AutoscalerArg = "--scale-down-delay-after-delete"
 	ScaleDownDelayAfterFailureArg   AutoscalerArg = "--scale-down-delay-after-failure"
+	ScaleDownUnneededTimeArg        AutoscalerArg = "--scale-down-unneeded-time"
 	MaxNodesTotalArg                AutoscalerArg = "--max-nodes-total"
 	CoresTotalArg                   AutoscalerArg = "--cores-total"
 	MemoryTotalArg                  AutoscalerArg = "--memory-total"
@@ -94,6 +95,10 @@ func ScaleDownArgs(sd *v1alpha1.ScaleDownConfig) []string {
 		ScaleDownDelayAfterAddArg.Value(sd.DelayAfterAdd),
 		ScaleDownDelayAfterDeleteArg.Value(sd.DelayAfterDelete),
 		ScaleDownDelayAfterFailureArg.Value(sd.DelayAfterFailure),
+	}
+
+	if sd.UnneededTime != "" {
+		args = append(args, ScaleDownUnneededTimeArg.Value(sd.UnneededTime))
 	}
 
 	return args


### PR DESCRIPTION
It takes 10 minutes before a cluster is scalled down (default value of --scale-down-unneeded-time).
Allowing to override the option allows to decrease the time spend waiting
on scale down operation in both testing and development environment.

Also can help customer to scale down sooner.