### PR TITLE
Revert "Disabling ExpectClusterAutoscalerAvailable e2e test temporarily."

### DIFF
--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -67,14 +67,11 @@ func runSuite() error {
 	}
 	glog.Info("PASS: CreateClusterAutoscaler")
 
-	// TODO: Disabled temporarily, remove after https://github.com/openshift/kubernetes-autoscaler/pull/29 got merged.
-	//       Since openshift installer is using machine.openshift.io instead of cluster.k8s.io,
-	//       above PR can't be merged yet due to circualr dependency. Commented out test allows this PR #35 to get merged.
-	// if err := ExpectClusterAutoscalerAvailable(); err != nil {
-	// 	glog.Errorf("FAIL: ExpectClusterAutoscalerAvailable: %v", err)
-	// 	return err
-	// }
-	// glog.Info("PASS: ExpectClusterAutoscalerAvailable")
+	if err := ExpectClusterAutoscalerAvailable(); err != nil {
+		glog.Errorf("FAIL: ExpectClusterAutoscalerAvailable: %v", err)
+		return err
+	}
+	glog.Info("PASS: ExpectClusterAutoscalerAvailable")
 
 	return nil
 }


### PR DESCRIPTION
This reverts commit a9fe0c752a179de93b199f2adfcd139d500987e6.

***Commented out test allowed PR #35 getting merged.***

Waiting for https://github.com/openshift/kubernetes-autoscaler/pull/29 to get merged.