### PR TITLE
Change namespace to openshift-machine-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The operator manages the following custom resources:
     Args:
       --logtostderr
       --cloud-provider=cluster-api
-      --namespace=openshift-cluster-api
+      --namespace=openshift-machine-api
       --expendable-pods-priority-cutoff=-10
       --max-nodes-total=24
       --cores-total=8:128
@@ -56,21 +56,22 @@ The operator manages the following custom resources:
 $ make build
 $ make test
 
-$ export WATCH_NAMESPACE=openshift-cluster-api
+$ export WATCH_NAMESPACE=openshift-machine-api
 $ ./bin/cluster-autoscaler-operator -alsologtostderr
 ```
 
 The Cluster Autoscaler Operator is designed to be deployed on
 OpenShift by the [Cluster Version Operator][CVO], but it's possible to
 run it directly on any vanilla Kubernetes cluster that has the
-[cluster-api][cluster-api] components available.  To do so, apply the
+[machine-api][machine-api] components available.  To do so, apply the
 manifests in the install directory: `kubectl apply -f ./install`
 
-This will create the `openshift-cluster-api` namespace, register the
+This will create the `openshift-machine-api` namespace, register the
 custom resource definitions, configure RBAC policies, and create a
 deployment for the operator.
 
 [CVO]: https://github.com/openshift/cluster-version-operator
+[machine-api]: https://github.com/openshift/cluster-api
 [cluster-api]: https://github.com/kubernetes-sigs/cluster-api
 
 

--- a/examples/machineautoscaler.yaml
+++ b/examples/machineautoscaler.yaml
@@ -3,7 +3,7 @@ apiVersion: "autoscaling.openshift.io/v1alpha1"
 kind: "MachineAutoscaler"
 metadata:
   name: "worker-us-east-1a"
-  namespace: "openshift-cluster-api"
+  namespace: "openshift-machine-api"
 spec:
   minReplicas: 1
   maxReplicas: 12

--- a/install/0000_50_cluster-autoscaler-operator_00_namespace.yaml
+++ b/install/0000_50_cluster-autoscaler-operator_00_namespace.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-cluster-api
+  name: openshift-machine-api
   labels:
-    name: openshift-cluster-api
+    name: openshift-machine-api
     openshift.io/run-level: "1"

--- a/install/0000_50_cluster-autoscaler-operator_03_rbac.yaml
+++ b/install/0000_50_cluster-autoscaler-operator_03_rbac.yaml
@@ -16,7 +16,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: cluster-autoscaler-operator
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
 rules:
 - apiGroups:
   - autoscaling.openshift.io
@@ -62,11 +62,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: cluster-autoscaler-operator
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
 subjects:
 - kind: ServiceAccount
   name: cluster-autoscaler-operator
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
 roleRef:
   kind: Role
   name: cluster-autoscaler-operator
@@ -84,14 +84,14 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: cluster-autoscaler-operator
-    namespace: openshift-cluster-api
+    namespace: openshift-machine-api
 
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cluster-autoscaler-operator
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
 
 ---
 apiVersion: v1
@@ -101,7 +101,7 @@ metadata:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -155,7 +155,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cluster-autoscaler
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
   labels:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
@@ -183,14 +183,14 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: cluster-autoscaler
-    namespace: openshift-cluster-api
+    namespace: openshift-machine-api
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cluster-autoscaler
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
   labels:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
@@ -201,4 +201,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: cluster-autoscaler
-    namespace: openshift-cluster-api
+    namespace: openshift-machine-api

--- a/install/0000_50_cluster-autoscaler-operator_04_deployment.yaml
+++ b/install/0000_50_cluster-autoscaler-operator_04_deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cluster-autoscaler-operator
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
   labels:
     k8s-app: cluster-autoscaler-operator
 spec:

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -10,7 +10,7 @@ import (
 const (
 	// DefaultWatchNamespace is the default namespace the operator
 	// will watch for instances of its custom resources.
-	DefaultWatchNamespace = "openshift-cluster-api"
+	DefaultWatchNamespace = "openshift-machine-api"
 
 	// DefaultLeaderElection controls whether the default
 	// configuration performs leader-election on startup.
@@ -18,7 +18,7 @@ const (
 
 	// DefaultLeaderElectionNamespace is the default namespace in
 	// which the leader-election ConfigMap will be created.
-	DefaultLeaderElectionNamespace = "openshift-cluster-api"
+	DefaultLeaderElectionNamespace = "openshift-machine-api"
 
 	// DefaultLeaderElectionID is the default name for the ConfigMap
 	// used for leader-election.
@@ -26,7 +26,7 @@ const (
 
 	// DefaultClusterAutoscalerNamespace is the default namespace for
 	// cluster-autoscaler deployments.
-	DefaultClusterAutoscalerNamespace = "openshift-cluster-api"
+	DefaultClusterAutoscalerNamespace = "openshift-machine-api"
 
 	// DefaultClusterAutoscalerName is the default ClusterAutoscaler
 	// object watched by the operator.

--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	namespace = "openshift-cluster-api"
+	namespace = "openshift-machine-api"
 	caName    = "default"
 )
 


### PR DESCRIPTION
Change namespace to openshift-machine-api
Needs https://github.com/openshift/machine-api-operator/pull/202 and counterpart installer PR https://github.com/openshift/installer/pull/1215