### PR TITLE
example: update apiVersion to use machine.openshift.io

### DIFF
--- a/examples/machineautoscaler.yaml
+++ b/examples/machineautoscaler.yaml
@@ -8,6 +8,6 @@ spec:
   minReplicas: 1
   maxReplicas: 12
   scaleTargetRef:
-    apiVersion: cluster.k8s.io/v1alpha1
+    apiVersion: machine.openshift.io/v1beta1
     kind: MachineSet
     name: worker


### PR DESCRIPTION
Update the MachineAutoscaler example to use the
machine.openshift.io/v1beta1 api version.