### PR TITLE
 Add cluster-critical priority to autoscaler-operator

### DIFF
--- a/install/0000_50_cluster-autoscaler-operator_04_deployment.yaml
+++ b/install/0000_50_cluster-autoscaler-operator_04_deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         k8s-app: cluster-autoscaler-operator
     spec:
+      priorityClassName: system-node-critical
       serviceAccountName: cluster-autoscaler-operator
       containers:
       - name: cluster-autoscaler-operator


### PR DESCRIPTION
As of now, cluster-autoscaler-operator doesn't have `system-node-critical` priorityClass names, the pods created for this deployment may get evicted by scheduler, if this priorityClass is not available. The rationale behind adding `system-node-critical` is we have nodeSelector to ensure that we are running on master nodes.