### PR TITLE
Remove resource limits in operator deployment

### DIFF
--- a/install/0000_50_cluster-autoscaler-operator_04_deployment.yaml
+++ b/install/0000_50_cluster-autoscaler-operator_04_deployment.yaml
@@ -40,9 +40,6 @@ spec:
         - name: CLUSTER_AUTOSCALER_IMAGE
           value: docker.io/openshift/origin-cluster-autoscaler:v4.0
         resources:
-          limits:
-            cpu: 20m
-            memory: 50Mi
           requests:
             cpu: 20m
             memory: 50Mi


### PR DESCRIPTION
This was reported in Bugzilla. Second-level-operators are expected to set resource requests, but explicitly should *not* set limits.