### PR TITLE
Override default CAO image

### DIFF
--- a/cluster-autoscaler-operator-patch.yaml
+++ b/cluster-autoscaler-operator-patch.yaml
@@ -9,6 +9,7 @@ spec:
     spec:
       containers:
       - name: cluster-autoscaler-operator
+        image: quay.io/openshift/origin-cluster-autoscaler-operator:v4.0
         env:
         - name: WATCH_NAMESPACE
           value: kube-system


### PR DESCRIPTION
Currently specified image docker.io/openshift/origin-cluster-autoscaler-operator:v4.0 is not available.
Using the one in quay instead.