### PR TITLE
Allow additional arguments to cluster-autoscaler

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -383,7 +383,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:d562e86a00e1439011e117b30a4f5872fe4ed448044c4bceaae2d9bbd64b3738"
+  digest = "1:fda26b4b3cc8dc89575c57b4c141db0cf03051c65a7296e143683e1bd8aa9962"
   name = "github.com/openshift/cluster-api-actuator-pkg"
   packages = [
     "pkg/e2e",
@@ -396,7 +396,7 @@
     "pkg/types",
   ]
   pruneopts = "N"
-  revision = "3efa4690c70f9ae43099944c3eb4ba66d9e8c325"
+  revision = "6da15dab1653f3bc0d878366ce9f7c91e4ba08d0"
 
 [[projects]]
   branch = "master"
@@ -882,6 +882,14 @@
     "rest",
     "rest/watch",
     "restmapper",
+    "scale",
+    "scale/scheme",
+    "scale/scheme/appsint",
+    "scale/scheme/appsv1beta1",
+    "scale/scheme/appsv1beta2",
+    "scale/scheme/autoscalingv1",
+    "scale/scheme/extensionsint",
+    "scale/scheme/extensionsv1beta1",
     "testing",
     "third_party/forked/golang/template",
     "tools/auth",
@@ -994,6 +1002,14 @@
   ]
   pruneopts = "NT"
   revision = "d50a959ae76a85c7c262a9767ef29f37093c2b8a"
+
+[[projects]]
+  branch = "master"
+  digest = "1:31548b329da724707853e197eaa60861e5cdad83fa42778196c2ff6f58e91685"
+  name = "k8s.io/utils"
+  packages = ["pointer"]
+  pruneopts = "NT"
+  revision = "21c4ce38f2a793ec01e925ddc31216500183b773"
 
 [[projects]]
   digest = "1:e03ddaf9f31bccbbb8c33eabad2c85025a95ca98905649fd744e0a54c630a064"

--- a/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
@@ -55,6 +55,8 @@ type Config struct {
 	CloudProvider string
 	// The log verbosity level for the cluster-autoscaler.
 	Verbosity int
+	// Additional arguments passed to the cluster-autoscaler.
+	ExtraArgs string
 }
 
 var _ reconcile.Reconciler = &Reconciler{}
@@ -314,6 +316,10 @@ func (r *Reconciler) AutoscalerDeployment(ca *autoscalingv1alpha1.ClusterAutosca
 // to the given ClusterAutoscaler.
 func (r *Reconciler) AutoscalerPodSpec(ca *autoscalingv1alpha1.ClusterAutoscaler) *corev1.PodSpec {
 	args := AutoscalerArgs(ca, r.config)
+
+	if r.config.ExtraArgs != "" {
+		args = append(args, r.config.ExtraArgs)
+	}
 
 	spec := &corev1.PodSpec{
 		ServiceAccountName: caServiceAccount,

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -92,6 +92,15 @@ type Config struct {
 	// ClusterAutoscalerVerbosity is the logging verbosity level for
 	// ClusterAutoscaler deployments.
 	ClusterAutoscalerVerbosity int
+
+	// ClusterAutoscalerExtraArgs is a string of additional arguments
+	// passed to all ClusterAutoscaler deployments.
+	//
+	// This is not exposed in the CRD.  It is only configurable via
+	// environment variable, and in a normal OpenShift install the CVO
+	// will remove it if set manually.  It is only for development and
+	// debugging purposes.
+	ClusterAutoscalerExtraArgs string
 }
 
 // NewConfig returns a new Config object with defaults set.
@@ -165,6 +174,10 @@ func ConfigFromEnvironment() *Config {
 		}
 
 		config.ClusterAutoscalerVerbosity = v
+	}
+
+	if caExtraArgs, ok := os.LookupEnv("CLUSTER_AUTOSCALER_EXTRA_ARGS"); ok {
+		config.ClusterAutoscalerExtraArgs = caExtraArgs
 	}
 
 	return config

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -86,6 +86,7 @@ func (o *Operator) AddControllers() error {
 		Namespace:      o.config.ClusterAutoscalerNamespace,
 		CloudProvider:  o.config.ClusterAutoscalerCloudProvider,
 		Verbosity:      o.config.ClusterAutoscalerVerbosity,
+		ExtraArgs:      o.config.ClusterAutoscalerExtraArgs,
 	})
 
 	o.checker = ca

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/autoscaler/autoscaler.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/autoscaler/autoscaler.go
@@ -26,7 +26,6 @@ func newWorkLoad() *batchv1.Job {
 	backoffLimit := int32(4)
 	completions := int32(50)
 	parallelism := int32(50)
-	activeDeadlineSeconds := int64(100)
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "workload",
@@ -67,10 +66,9 @@ func newWorkLoad() *batchv1.Job {
 					},
 				},
 			},
-			ActiveDeadlineSeconds: &activeDeadlineSeconds,
-			BackoffLimit:          &backoffLimit,
-			Completions:           &completions,
-			Parallelism:           &parallelism,
+			BackoffLimit: &backoffLimit,
+			Completions:  &completions,
+			Parallelism:  &parallelism,
 		},
 	}
 }

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/infra/infra.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/infra/infra.go
@@ -2,7 +2,6 @@ package infra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -10,261 +9,269 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 	e2e "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework"
-	mapiv1beta1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
-	controllernode "github.com/openshift/cluster-api/pkg/controller/node"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/pointer"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = g.Describe("[Feature:Machines] Machines should", func() {
+var _ = g.Describe("[Feature:Machines] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
-	g.It("be linked with nodes", func() {
+	g.It("have machines linked with nodes", func() {
 		var err error
 		client, err := e2e.LoadClient()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		listOptions := runtimeclient.ListOptions{
-			Namespace: e2e.TestContext.MachineApiNamespace,
+		o.Expect(isOneMachinePerNode(client)).To(o.BeTrue())
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.It("have ability to additively reconcile taints from machine to nodes", func() {
+		var err error
+		client, err := e2e.LoadClient()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		machines, err := getMachines(client)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(machines)).To(o.BeNumerically(">", 0))
+		machine := machines[0]
+		originalMachineTaints := machine.Spec.Taints
+		g.By(fmt.Sprintf("getting machine %q", machine.Name))
+
+		node, err := getNodeFromMachine(client, machine)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		originalNodeTaints := node.Spec.Taints
+		g.By(fmt.Sprintf("getting the backed node %q", node.Name))
+
+		nodeTaint := corev1.Taint{
+			Key:    "not-from-machine",
+			Value:  "true",
+			Effect: corev1.TaintEffectNoSchedule,
 		}
-		machineList := mapiv1beta1.MachineList{}
-		nodeList := corev1.NodeList{}
+		g.By(fmt.Sprintf("updating node %q with taint: %v", node.Name, nodeTaint))
+		node.Spec.Taints = append(node.Spec.Taints, nodeTaint)
+		err = client.Update(context.TODO(), node)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-		err = wait.PollImmediate(5*time.Second, e2e.WaitShort, func() (bool, error) {
-			if err := client.List(context.TODO(), &listOptions, &machineList); err != nil {
-				glog.Errorf("error querying api for machineList object: %v, retrying...", err)
-				return false, nil
-			}
-			if err := client.List(context.TODO(), &listOptions, &nodeList); err != nil {
-				glog.Errorf("error querying api for nodeList object: %v, retrying...", err)
-				return false, nil
-			}
+		machineTaint := corev1.Taint{
+			Key:    fmt.Sprintf("from-machine-%v", string(uuid.NewUUID())),
+			Value:  "true",
+			Effect: corev1.TaintEffectNoSchedule,
+		}
+		g.By(fmt.Sprintf("updating machine %q with taint: %v", machine.Name, machineTaint))
+		machine.Spec.Taints = append(machine.Spec.Taints, machineTaint)
+		err = client.Update(context.TODO(), &machine)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-			// Every machine needs to be linked to a node, though some nodes do not have to linked to any machines
-			glog.Infof("Expecting at least the same number of machines as nodes, have %v nodes and %v machines", len(nodeList.Items), len(machineList.Items))
-			if len(machineList.Items) > len(nodeList.Items) {
-				return false, nil
+		var expectedTaints = sets.NewString("not-from-machine", machineTaint.Key)
+		o.Eventually(func() bool {
+			glog.Info("Getting node from machine again for verification of taints")
+			node, err := getNodeFromMachine(client, machine)
+			if err != nil {
+				return false
 			}
-
-			nodeNameToMachineAnnotation := make(map[string]string)
-			for _, node := range nodeList.Items {
-				nodeNameToMachineAnnotation[node.Name] = node.Annotations[controllernode.MachineAnnotationKey]
+			var observedTaints = sets.NewString()
+			for _, taint := range node.Spec.Taints {
+				observedTaints.Insert(taint.Key)
 			}
-			for _, machine := range machineList.Items {
-				if machine.Status.NodeRef == nil {
-					glog.Errorf("machine %s has no NodeRef, retrying...", machine.Name)
-					return false, nil
-				}
-				nodeName := machine.Status.NodeRef.Name
-				if nodeNameToMachineAnnotation[nodeName] != fmt.Sprintf("%s/%s", e2e.TestContext.MachineApiNamespace, machine.Name) {
-					glog.Errorf("node name %s does not match expected machine name %s, retrying...", nodeName, machine.Name)
-					return false, nil
-				}
-				glog.Infof("Machine %q is linked to node %q", machine.Name, nodeName)
+			if expectedTaints.Difference(observedTaints).HasAny("not-from-machine", machineTaint.Key) == false {
+				glog.Infof("Expected : %v, observed %v , difference %v, ", expectedTaints, observedTaints, expectedTaints.Difference(observedTaints))
+				return true
 			}
-			return true, nil
-		})
+			glog.Infof("Did not find all expected taints on the node. Missing: %v", expectedTaints.Difference(observedTaints))
+			return false
+		}, e2e.WaitMedium, 5*time.Second).Should(o.BeTrue())
+		// set back original taints
+		machine.Spec.Taints = originalMachineTaints
+		err = client.Update(context.TODO(), &machine)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		node, err = getNodeFromMachine(client, machine)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		node.Spec.Taints = originalNodeTaints
+		err = client.Update(context.TODO(), node)
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("have ability to additively reconcile taints", func() {
+	g.It("recover from deleted worker machines", func() {
 		var err error
 		client, err := e2e.LoadClient()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		g.By("Verify machine taints are getting applied to node")
-		err = func() error {
-			listOptions := runtimeclient.ListOptions{
-				Namespace: e2e.TestContext.MachineApiNamespace,
-			}
-			machineList := mapiv1beta1.MachineList{}
-
-			if err := client.List(context.TODO(), &listOptions, &machineList); err != nil {
-				return fmt.Errorf("error querying api for machineList object: %v", err)
-			}
-			g.By("Got the machine list")
-			machine := machineList.Items[0]
-			if machine.Status.NodeRef == nil {
-				return fmt.Errorf("machine %s has no NodeRef", machine.Name)
-			}
-			g.By(fmt.Sprintf("Got the machine %s", machine.Name))
-			nodeName := machine.Status.NodeRef.Name
-			nodeKey := types.NamespacedName{
-				Namespace: e2e.TestContext.MachineApiNamespace,
-				Name:      nodeName,
-			}
-			node := &corev1.Node{}
-
-			if err := client.Get(context.TODO(), nodeKey, node); err != nil {
-				return fmt.Errorf("error querying api for node object: %v", err)
-			}
-			g.By(fmt.Sprintf("Got the node %s from machine, %s", node.Name, machine.Name))
-			nodeTaint := corev1.Taint{
-				Key:    "not-from-machine",
-				Value:  "true",
-				Effect: corev1.TaintEffectNoSchedule,
-			}
-			// Do not remove any taint, just extend the list
-			// The test removes the nodes anyway, so the list will not grow over time much
-			node.Spec.Taints = append(node.Spec.Taints, nodeTaint)
-			if err := client.Update(context.TODO(), node); err != nil {
-				return fmt.Errorf("error updating node object with non-machine taint: %v", err)
-			}
-			g.By("Updated node object with taint")
-			machineTaint := corev1.Taint{
-				Key:    fmt.Sprintf("from-machine-%v", string(uuid.NewUUID())),
-				Value:  "true",
-				Effect: corev1.TaintEffectNoSchedule,
-			}
-
-			// Do not remove any taint, just extend the list
-			// The test removes the machine anyway, so the list will not grow over time much
-			machine.Spec.Taints = append(machine.Spec.Taints, machineTaint)
-			if err := client.Update(context.TODO(), &machine); err != nil {
-				return fmt.Errorf("error updating machine object with taint: %v", err)
-			}
-
-			g.By("Updated machine object with taint")
-			var expectedTaints = sets.NewString("not-from-machine", machineTaint.Key)
-			err := wait.PollImmediate(1*time.Second, e2e.WaitLong, func() (bool, error) {
-				if err := client.Get(context.TODO(), nodeKey, node); err != nil {
-					glog.Errorf("error querying api for node object: %v", err)
-					return false, nil
-				}
-				glog.Info("Got the node again for verification of taints")
-				var observedTaints = sets.NewString()
-				for _, taint := range node.Spec.Taints {
-					observedTaints.Insert(taint.Key)
-				}
-				if expectedTaints.Difference(observedTaints).HasAny("not-from-machine", machineTaint.Key) == false {
-					glog.Infof("expected : %v, observed %v , difference %v, ", expectedTaints, observedTaints, expectedTaints.Difference(observedTaints))
-					return true, nil
-				}
-				glog.Infof("Did not find all expected taints on the node. Missing: %v", expectedTaints.Difference(observedTaints))
-				return false, nil
-			})
-			return err
-		}()
-		o.Expect(err).NotTo(o.HaveOccurred())
-	})
-
-	g.It("be replaced with new one when deleted", func() {
-		var err error
-		client, err := e2e.LoadClient()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		// Assume cluster state
+		// Expect for cluster to cool down from previous tests
 		err = e2e.WaitUntilAllNodesAreReady(client)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		glog.Info("Get machineList")
-		machineList := mapiv1beta1.MachineList{}
-		err = wait.PollImmediate(1*time.Second, e2e.WaitShort, func() (bool, error) {
-			if err := client.List(context.TODO(), runtimeclient.InNamespace(e2e.TestContext.MachineApiNamespace), &machineList); err != nil {
-				glog.Errorf("error querying api for machineList object: %v, retrying...", err)
-				return false, nil
-			}
-			return true, nil
-		})
+		g.By("checking initial cluster state")
+		initialClusterSize, err := getClusterSize(client)
+		waitForClusterSizeToBeHealthy(initialClusterSize)
+
+		workerNode, err := getWorkerNode(client)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		workerMachine, err := getMachineFromNode(client, workerNode)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		g.By(fmt.Sprintf("deleting machine object %q", workerMachine.Name))
+		err = deleteMachine(client, workerMachine)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		glog.Info("Get nodeList")
+		g.By(fmt.Sprintf("waiting for node object %q to go away", workerNode.Name))
 		nodeList := corev1.NodeList{}
-		err = wait.PollImmediate(1*time.Second, e2e.WaitShort, func() (bool, error) {
+		o.Eventually(func() bool {
 			if err := client.List(context.TODO(), nil, &nodeList); err != nil {
-				glog.Errorf("error querying api for nodeList object: %v, retrying...", err)
-				return false, nil
+				glog.Errorf("Error querying api for nodeList object: %v, retrying...", err)
+				return false
 			}
-			return true, nil
-		})
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		clusterInitialTotalNodes := len(nodeList.Items)
-		clusterInitialTotalMachines := len(machineList.Items)
-		var triagedWorkerMachine *mapiv1beta1.Machine
-		var triagedWorkerNode *corev1.Node
-
-		glog.Infof("Initial number of nodes: %v, initial number of machines: %v", clusterInitialTotalNodes, clusterInitialTotalMachines)
-
-		err = func() error {
-			for _, machine := range machineList.Items {
-				if machine.Status.NodeRef == nil {
-					glog.Infof("Machine %q is not linked to any node", machine.Name)
-					continue
-				}
-				node := corev1.Node{}
-				if err := client.Get(context.TODO(), types.NamespacedName{Name: machine.Status.NodeRef.Name}, &node); err != nil {
-					glog.Errorf("error querying api for node object: %v, retrying...", err)
-					continue
-				}
-
-				if node.Labels == nil {
-					continue
-				}
-
-				if _, exists := node.Labels["node-role.kubernetes.io/worker"]; !exists {
-					continue
-				}
-
-				triagedWorkerNode = node.DeepCopy()
-				triagedWorkerMachine = machine.DeepCopy()
-				break
-			}
-			if triagedWorkerMachine == nil {
-				return errors.New("Unable to find any worker machine")
-			}
-			return nil
-		}()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		glog.Infof("Delete machine %v", triagedWorkerMachine.Name)
-		err = wait.PollImmediate(1*time.Second, e2e.WaitShort, func() (bool, error) {
-			if err := client.Delete(context.TODO(), triagedWorkerMachine); err != nil {
-				glog.Errorf("error querying api for Deployment object: %v, retrying...", err)
-				return false, nil
-			}
-			return true, nil
-		})
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		err = wait.PollImmediate(5*time.Second, e2e.WaitMedium, func() (bool, error) {
-			if err := client.List(context.TODO(), runtimeclient.InNamespace(e2e.TestContext.MachineApiNamespace), &machineList); err != nil {
-				glog.Errorf("error querying api for machineList object: %v, retrying...", err)
-				return false, nil
-			}
-			glog.Info("Expect new machine to come up")
-			return len(machineList.Items) == clusterInitialTotalMachines, nil
-		})
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		err = wait.PollImmediate(5*time.Second, e2e.WaitLong, func() (bool, error) {
-			if err := client.List(context.TODO(), nil, &nodeList); err != nil {
-				glog.Errorf("error querying api for nodeList object: %v, retrying...", err)
-				return false, nil
-			}
-			glog.Info("Expect deleted machine node to go away")
 			for _, n := range nodeList.Items {
-				if n.Name == triagedWorkerNode.Name {
-					return false, nil
+				if n.Name == workerNode.Name {
+					glog.Infof("Node %q still exists. Node conditions are: %v", workerNode.Name, workerNode.Status.Conditions)
+					return false
 				}
 			}
-			return true, nil
-		})
-		o.Expect(err).NotTo(o.HaveOccurred())
+			return true
+		}, e2e.WaitLong, 5*time.Second).Should(o.BeTrue())
 
-		err = wait.PollImmediate(5*time.Second, e2e.WaitLong, func() (bool, error) {
-			if err := client.List(context.TODO(), nil, &nodeList); err != nil {
-				glog.Errorf("error querying api for nodeList object: %v, retrying...", err)
-				return false, nil
-			}
-			glog.Info("Expect new node to come up")
-			return len(nodeList.Items) == clusterInitialTotalNodes, nil
-		})
-		o.Expect(err).NotTo(o.HaveOccurred())
+		g.By(fmt.Sprintf("waiting for new node object to come up"))
+		waitForClusterSizeToBeHealthy(initialClusterSize)
 	})
 
+	g.It("grow or decrease when scaling out or in", func() {
+		g.By("checking initial cluster state")
+		client, err := e2e.LoadClient()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		initialClusterSize, err := getClusterSize(client)
+		waitForClusterSizeToBeHealthy(initialClusterSize)
+
+		machineSets, err := getMachineSets(client)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(machineSets)).To(o.BeNumerically(">", 2))
+		machineSet := machineSets[0]
+		initialReplicasMachineSet := int(pointer.Int32PtrDerefOr(machineSet.Spec.Replicas, 0))
+		scaleOut := 3
+		scaleIn := initialReplicasMachineSet
+		originalReplicas := initialReplicasMachineSet
+		clusterGrowth := scaleOut - originalReplicas
+		clusterDecrease := scaleOut - scaleIn
+		intermediateClusterSize := initialClusterSize + clusterGrowth
+		finalClusterSize := initialClusterSize + clusterGrowth - clusterDecrease
+
+		g.By(fmt.Sprintf("scaling out %q machineSet to %d replicas", machineSet.Name, scaleOut))
+		err = scaleMachineSet(machineSet.Name, scaleOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("waiting for cluster to grow %d nodes. Size should be %d", clusterGrowth, intermediateClusterSize))
+		waitForClusterSizeToBeHealthy(intermediateClusterSize)
+
+		g.By(fmt.Sprintf("scaling in %q machineSet to %d replicas", machineSet.Name, scaleIn))
+		err = scaleMachineSet(machineSet.Name, scaleIn)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("waiting for cluster to decrease %d nodes. Final size should be %d nodes", clusterDecrease, finalClusterSize))
+		waitForClusterSizeToBeHealthy(finalClusterSize)
+	})
+
+	g.It("grow and decrease when scaling different machineSets simultaneously", func() {
+		client, err := e2e.LoadClient()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		scaleOut := 3
+
+		g.By("checking initial cluster size")
+		initialClusterSize, err := getClusterSize(client)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("getting worker machineSets")
+		machineSets, err := getMachineSets(client)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(machineSets)).To(o.BeNumerically(">", 2))
+		machineSet0 := machineSets[0]
+		initialReplicasMachineSet0 := int(pointer.Int32PtrDerefOr(machineSet0.Spec.Replicas, 0))
+		machineSet1 := machineSets[1]
+		initialReplicasMachineSet1 := int(pointer.Int32PtrDerefOr(machineSet1.Spec.Replicas, 0))
+
+		g.By(fmt.Sprintf("scaling %q from %d to %d replicas", machineSet0.Name, initialReplicasMachineSet0, scaleOut))
+		err = scaleMachineSet(machineSet0.Name, scaleOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("scaling %q from %d to %d replicas", machineSet1.Name, initialReplicasMachineSet1, scaleOut))
+		err = scaleMachineSet(machineSet1.Name, scaleOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		o.Eventually(func() bool {
+			nodes, err := getNodesFromMachineSet(client, machineSet0)
+			if err != nil {
+				return false
+			}
+			return len(nodes) == scaleOut && nodesAreReady(nodes)
+		}, e2e.WaitLong, 5*time.Second).Should(o.BeTrue())
+
+		o.Eventually(func() bool {
+			nodes, err := getNodesFromMachineSet(client, machineSet1)
+			if err != nil {
+				return false
+			}
+			return len(nodes) == scaleOut && nodesAreReady(nodes)
+		}, e2e.WaitLong, 5*time.Second).Should(o.BeTrue())
+
+		g.By(fmt.Sprintf("scaling %q from %d to %d replicas", machineSet0.Name, scaleOut, initialReplicasMachineSet0))
+		err = scaleMachineSet(machineSet0.Name, initialReplicasMachineSet0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("scaling %q from %d to %d replicas", machineSet1.Name, scaleOut, initialReplicasMachineSet1))
+		err = scaleMachineSet(machineSet1.Name, initialReplicasMachineSet1)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("waiting for cluster to get back to original size. Final size should be %d nodes", initialClusterSize))
+		waitForClusterSizeToBeHealthy(initialClusterSize)
+	})
 })
+
+func waitForClusterSizeToBeHealthy(targetSize int) {
+	client, err := e2e.LoadClient()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	o.Eventually(func() int {
+		glog.Infof("Cluster size expected to be %d nodes", targetSize)
+		err := machineSetsSnapShotLogs(client)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = nodesSnapShotLogs(client)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		finalClusterSize, err := getClusterSize(client)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		return finalClusterSize
+	}, e2e.WaitLong, 5*time.Second).Should(o.BeNumerically("==", targetSize))
+
+	g.By(fmt.Sprintf("waiting for all nodes to be ready"))
+	err = e2e.WaitUntilAllNodesAreReady(client)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By(fmt.Sprintf("waiting for all nodes to be schedulable"))
+	err = waitUntilAllNodesAreSchedulable(client)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By(fmt.Sprintf("waiting for each node to be backed by a machine"))
+	o.Expect(isOneMachinePerNode(client)).To(o.BeTrue())
+}
+
+// waitUntilAllNodesAreSchedulable waits for all cluster nodes to be schedulable and returns an error otherwise
+func waitUntilAllNodesAreSchedulable(client runtimeclient.Client) error {
+	return wait.PollImmediate(1*time.Second, time.Minute, func() (bool, error) {
+		nodeList := corev1.NodeList{}
+		if err := client.List(context.TODO(), &runtimeclient.ListOptions{}, &nodeList); err != nil {
+			glog.Errorf("error querying api for nodeList object: %v, retrying...", err)
+			return false, nil
+		}
+		// All nodes needs to be schedulable
+		for _, node := range nodeList.Items {
+			if node.Spec.Unschedulable == true {
+				glog.Errorf("Node %q is unschedulable", node.Name)
+				return false, nil
+			}
+			glog.Infof("Node %q is schedulable", node.Name)
+		}
+		return true, nil
+	})
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/infra/utils.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/infra/utils.go
@@ -1,0 +1,368 @@
+package infra
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	e2e "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework"
+	mapiv1beta1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+	controllernode "github.com/openshift/cluster-api/pkg/controller/node"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/scale"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/pointer"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+const (
+	nodeWorkerRoleLabel = "node-role.kubernetes.io/worker"
+	machineRoleLabel    = "machine.openshift.io/cluster-api-machine-role"
+	machineAPIGroup     = "machine.openshift.io"
+)
+
+func isOneMachinePerNode(client runtimeclient.Client) bool {
+	listOptions := runtimeclient.ListOptions{
+		Namespace: e2e.TestContext.MachineApiNamespace,
+	}
+	machineList := mapiv1beta1.MachineList{}
+	nodeList := corev1.NodeList{}
+
+	if err := wait.PollImmediate(5*time.Second, e2e.WaitShort, func() (bool, error) {
+		if err := client.List(context.TODO(), &listOptions, &machineList); err != nil {
+			glog.Errorf("Error querying api for machineList object: %v, retrying...", err)
+			return false, nil
+		}
+		if err := client.List(context.TODO(), &listOptions, &nodeList); err != nil {
+			glog.Errorf("Error querying api for nodeList object: %v, retrying...", err)
+			return false, nil
+		}
+
+		glog.Infof("Expecting the same number of machines and nodes, have %d nodes and %d machines", len(nodeList.Items), len(machineList.Items))
+		if len(machineList.Items) != len(nodeList.Items) {
+			return false, nil
+		}
+
+		nodeNameToMachineAnnotation := make(map[string]string)
+		for _, node := range nodeList.Items {
+			if _, ok := node.Annotations[controllernode.MachineAnnotationKey]; !ok {
+				glog.Errorf("Node %q does not have a MachineAnnotationKey %q, retrying...", node.Name, controllernode.MachineAnnotationKey)
+				return false, nil
+			}
+			nodeNameToMachineAnnotation[node.Name] = node.Annotations[controllernode.MachineAnnotationKey]
+		}
+		for _, machine := range machineList.Items {
+			if machine.Status.NodeRef == nil {
+				glog.Errorf("Machine %q has no NodeRef, retrying...", machine.Name)
+				return false, nil
+			}
+			nodeName := machine.Status.NodeRef.Name
+			if nodeNameToMachineAnnotation[nodeName] != fmt.Sprintf("%s/%s", e2e.TestContext.MachineApiNamespace, machine.Name) {
+				glog.Errorf("Node name %q does not match expected machine name %q, retrying...", nodeName, machine.Name)
+				return false, nil
+			}
+			glog.Infof("Machine %q is linked to node %q", machine.Name, nodeName)
+		}
+		return true, nil
+	}); err != nil {
+		glog.Errorf("Error checking isOneMachinePerNode: %v", err)
+		return false
+	}
+	return true
+}
+
+// getClusterSize returns the number of nodes of the cluster
+func getClusterSize(client runtimeclient.Client) (int, error) {
+	nodeList := corev1.NodeList{}
+	if err := wait.PollImmediate(1*time.Second, time.Minute, func() (bool, error) {
+		if err := client.List(context.TODO(), &runtimeclient.ListOptions{}, &nodeList); err != nil {
+			glog.Errorf("Error querying api for nodeList object: %v, retrying...", err)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		glog.Errorf("Error calling getClusterSize: %v", err)
+		return 0, err
+	}
+	glog.Infof("Cluster size is %d nodes", len(nodeList.Items))
+	return len(nodeList.Items), nil
+}
+
+// machineSetsSnapShotLogs logs the state of all the machineSets in the cluster
+func machineSetsSnapShotLogs(client runtimeclient.Client) error {
+	machineSetList, err := getMachineSetList(client)
+	if err != nil {
+		return fmt.Errorf("error calling getMachineSetList: %v", err)
+	}
+	for key := range machineSetList.Items {
+		glog.Infof("MachineSet %q replicas %d. Ready: %d, available %d", machineSetList.Items[key].Name, pointer.Int32PtrDerefOr(machineSetList.Items[key].Spec.Replicas, 0), machineSetList.Items[key].Status.ReadyReplicas, machineSetList.Items[key].Status.AvailableReplicas)
+	}
+	return nil
+}
+
+// getMachineSetList returns a MachineSetList object
+func getMachineSetList(client runtimeclient.Client) (*mapiv1beta1.MachineSetList, error) {
+	machineSetList := mapiv1beta1.MachineSetList{}
+	listOptions := runtimeclient.ListOptions{
+		Namespace: e2e.TestContext.MachineApiNamespace,
+	}
+	if err := wait.PollImmediate(1*time.Second, time.Minute, func() (bool, error) {
+		if err := client.List(context.TODO(), &listOptions, &machineSetList); err != nil {
+			glog.Errorf("error querying api for machineSetList object: %v, retrying...", err)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		glog.Errorf("Error calling getMachineSetList: %v", err)
+		return nil, err
+	}
+	return &machineSetList, nil
+}
+
+// getMachineSets returns the list of machineSets or an error
+func getMachineSets(client runtimeclient.Client) ([]mapiv1beta1.MachineSet, error) {
+	machineSetList, err := getMachineSetList(client)
+	if err != nil {
+		return nil, fmt.Errorf("error getting machineSetList: %v", err)
+	}
+	if len(machineSetList.Items) == 0 {
+		return nil, fmt.Errorf("error getting machineSets, machineSetList is empty")
+	}
+	return machineSetList.Items, nil
+}
+
+// getMachineList returns a MachineList object
+func getMachineList(client runtimeclient.Client) (*mapiv1beta1.MachineList, error) {
+	machineList := mapiv1beta1.MachineList{}
+	listOptions := runtimeclient.ListOptions{
+		Namespace: e2e.TestContext.MachineApiNamespace,
+	}
+	if err := wait.PollImmediate(1*time.Second, time.Minute, func() (bool, error) {
+		if err := client.List(context.TODO(), &listOptions, &machineList); err != nil {
+			glog.Errorf("error querying api for machineList object: %v, retrying...", err)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		glog.Errorf("Error calling getMachineList: %v", err)
+		return nil, err
+	}
+	return &machineList, nil
+}
+
+// getMachines returns the list of machines or an error
+func getMachines(client runtimeclient.Client) ([]mapiv1beta1.Machine, error) {
+	machineList, err := getMachineList(client)
+	if err != nil {
+		return nil, fmt.Errorf("error getting machineList: %v", err)
+	}
+	return machineList.Items, nil
+}
+
+// getMachinesFromMachineSet returns an array of machines owned by a given machineSet
+func getMachinesFromMachineSet(client runtimeclient.Client, machineSet mapiv1beta1.MachineSet) ([]mapiv1beta1.Machine, error) {
+	machineList, err := getMachineList(client)
+	if err != nil {
+		return nil, fmt.Errorf("error getting machineList: %v", err)
+	}
+	var machinesForSet []mapiv1beta1.Machine
+	for key := range machineList.Items {
+		if metav1.IsControlledBy(&machineList.Items[key], &machineSet) {
+			machinesForSet = append(machinesForSet, machineList.Items[key])
+		}
+	}
+	return machinesForSet, nil
+}
+
+// getMachineFromNode returns the machine referenced by the "controllernode.MachineAnnotationKey" annotation in the given node
+func getMachineFromNode(client runtimeclient.Client, node *corev1.Node) (*mapiv1beta1.Machine, error) {
+	machineNamespaceKey, ok := node.Annotations[controllernode.MachineAnnotationKey]
+	if !ok {
+		return nil, fmt.Errorf("node %q does not have a MachineAnnotationKey %q", node.Name, controllernode.MachineAnnotationKey)
+	}
+	namespace, machineName, err := cache.SplitMetaNamespaceKey(machineNamespaceKey)
+	if err != nil {
+		return nil, fmt.Errorf("machine annotation format is incorrect %v: %v", machineNamespaceKey, err)
+	}
+
+	key := runtimeclient.ObjectKey{Namespace: namespace, Name: machineName}
+	machine := mapiv1beta1.Machine{}
+	if err := wait.PollImmediate(1*time.Second, time.Minute, func() (bool, error) {
+		if err := client.Get(context.TODO(), key, &machine); err != nil {
+			glog.Errorf("Error querying api for nodeList object: %v, retrying...", err)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		glog.Errorf("Error calling getMachineFromNode: %v", err)
+		return nil, err
+	}
+	return &machine, nil
+}
+
+// deleteMachine deletes a specific machine and returns an error otherwise
+func deleteMachine(client runtimeclient.Client, machine *mapiv1beta1.Machine) error {
+	return wait.PollImmediate(1*time.Second, time.Minute, func() (bool, error) {
+		if err := client.Delete(context.TODO(), machine); err != nil {
+			glog.Errorf("Error querying api for machine object %q: %v, retrying...", machine.Name, err)
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+// getNodesFromMachineSet returns an array of nodes backed by machines owned by a given machineSet
+func getNodesFromMachineSet(client runtimeclient.Client, machineSet mapiv1beta1.MachineSet) ([]*corev1.Node, error) {
+	machines, err := getMachinesFromMachineSet(client, machineSet)
+	if err != nil {
+		return nil, fmt.Errorf("error calling getMachinesFromMachineSet %v", err)
+	}
+
+	var nodes []*corev1.Node
+	for key := range machines {
+		node, err := getNodeFromMachine(client, machines[key])
+		if err != nil {
+			return nil, fmt.Errorf("error getting node from machine %q: %v", machines[key].Name, err)
+		}
+		nodes = append(nodes, node)
+	}
+	glog.Infof("MachineSet %q have %d nodes", machineSet.Name, len(nodes))
+	return nodes, nil
+}
+
+// getNodeFromMachine returns the node object referenced by machine.Status.NodeRef
+func getNodeFromMachine(client runtimeclient.Client, machine mapiv1beta1.Machine) (*corev1.Node, error) {
+	var node corev1.Node
+	if machine.Status.NodeRef == nil {
+		glog.Errorf("Machine %q has no NodeRef", machine.Name)
+		return nil, fmt.Errorf("machine %q has no NodeRef", machine.Name)
+	}
+	key := runtimeclient.ObjectKey{Namespace: machine.Status.NodeRef.Namespace, Name: machine.Status.NodeRef.Name}
+	if err := client.Get(context.Background(), key, &node); err != nil {
+		return nil, fmt.Errorf("error getting node %q: %v", node.Name, err)
+	}
+
+	glog.Infof("Machine %q is backing node %q", machine.Name, node.Name)
+	return &node, nil
+}
+
+// getWorkerNode returns a node with the nodeWorkerRoleLabel label
+func getWorkerNode(client runtimeclient.Client) (*corev1.Node, error) {
+	nodeList := corev1.NodeList{}
+	listOptions := runtimeclient.ListOptions{}
+	listOptions.MatchingLabels(map[string]string{nodeWorkerRoleLabel: ""})
+	if err := wait.PollImmediate(1*time.Second, time.Minute, func() (bool, error) {
+		if err := client.List(context.TODO(), &listOptions, &nodeList); err != nil {
+			glog.Errorf("Error querying api for nodeList object: %v, retrying...", err)
+			return false, nil
+		}
+		if len(nodeList.Items) < 1 {
+			glog.Errorf("No nodes were found with label %q", nodeWorkerRoleLabel)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		glog.Errorf("Error calling getWorkerMachine: %v", err)
+		return nil, err
+	}
+	return &nodeList.Items[0], nil
+}
+
+// nodesAreReady returns true if an array of nodes are all ready
+func nodesAreReady(nodes []*corev1.Node) bool {
+	// All nodes needs to be ready
+	for key := range nodes {
+		if !e2e.IsNodeReady(nodes[key]) {
+			glog.Errorf("Node %q is not ready. Conditions are: %v", nodes[key].Name, nodes[key].Status.Conditions)
+			return false
+		}
+		glog.Infof("Node %q is ready. Conditions are: %v", nodes[key].Name, nodes[key].Status.Conditions)
+	}
+	return true
+}
+
+// scaleMachineSet scales a machineSet with a given name to the given number of replicas
+func scaleMachineSet(name string, replicas int) error {
+	scaleClient, err := getScaleClient()
+	if err != nil {
+		return fmt.Errorf("error calling getScaleClient %v", err)
+	}
+
+	scale, err := scaleClient.Scales(e2e.TestContext.MachineApiNamespace).Get(schema.GroupResource{Group: machineAPIGroup, Resource: "MachineSet"}, name)
+	if err != nil {
+		return fmt.Errorf("error calling scaleClient.Scales get: %v", err)
+	}
+
+	scaleUpdate := scale.DeepCopy()
+	scaleUpdate.Spec.Replicas = int32(replicas)
+	_, err = scaleClient.Scales(e2e.TestContext.MachineApiNamespace).Update(schema.GroupResource{Group: machineAPIGroup, Resource: "MachineSet"}, scaleUpdate)
+	if err != nil {
+		return fmt.Errorf("error calling scaleClient.Scales update: %v", err)
+	}
+	return nil
+}
+
+// getScaleClient returns a ScalesGetter object to manipulate scale subresources
+func getScaleClient() (scale.ScalesGetter, error) {
+	cfg, err := e2e.LoadConfig()
+	if err != nil {
+		return nil, fmt.Errorf("error getting config %v", err)
+	}
+	mapper, err := apiutil.NewDiscoveryRESTMapper(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("error calling NewDiscoveryRESTMapper %v", err)
+	}
+
+	discovery := discovery.NewDiscoveryClientForConfigOrDie(cfg)
+	scaleKindResolver := scale.NewDiscoveryScaleKindResolver(discovery)
+	scaleClient, err := scale.NewForConfig(cfg, mapper, dynamic.LegacyAPIPathResolverFunc, scaleKindResolver)
+	if err != nil {
+		return nil, fmt.Errorf("error calling building scale client %v", err)
+	}
+	return scaleClient, nil
+}
+
+// nodesSnapShotLogs logs the state of all the nodes in the cluster
+func nodesSnapShotLogs(client runtimeclient.Client) error {
+	nodes, err := getNodes(client)
+	if err != nil {
+		return fmt.Errorf("error calling getNodes: %v", err)
+	}
+	for key := range nodes {
+		glog.Infof("Node %q. Ready: %t. Unschedulable: %t", nodes[key].Name, e2e.IsNodeReady(&nodes[key]), nodes[key].Spec.Unschedulable)
+	}
+	return nil
+}
+
+// getNodeList returns a nodeList object
+func getNodeList(client runtimeclient.Client) (*corev1.NodeList, error) {
+	nodeList := corev1.NodeList{}
+	listOptions := runtimeclient.ListOptions{}
+	if err := wait.PollImmediate(1*time.Second, time.Minute, func() (bool, error) {
+		if err := client.List(context.TODO(), &listOptions, &nodeList); err != nil {
+			glog.Errorf("error querying api for machineSetList object: %v, retrying...", err)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		glog.Errorf("Error calling getMachineSetList: %v", err)
+		return nil, err
+	}
+	return &nodeList, nil
+}
+
+// getNodes returns the list of nodes or an error
+func getNodes(client runtimeclient.Client) ([]corev1.Node, error) {
+	nodeList, err := getNodeList(client)
+	if err != nil {
+		return nil, fmt.Errorf("error getting nodeList: %v", err)
+	}
+	return nodeList.Items, nil
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/operators/machine-api-operator.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/operators/machine-api-operator.go
@@ -1,17 +1,11 @@
 package operators
 
 import (
-	"context"
 	"fmt"
-	"time"
 
-	"github.com/golang/glog"
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 	e2e "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework"
-	kappsapi "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 var _ = g.Describe("[Feature:Operators] Machine API operator deployment should", func() {
@@ -29,36 +23,19 @@ var _ = g.Describe("[Feature:Operators] Machine API operator deployment should",
 		client, err := e2e.LoadClient()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		controllersDeploymentKey := types.NamespacedName{
-			Namespace: e2e.TestContext.MachineApiNamespace,
-			Name:      "clusterapi-manager-controllers",
-		}
-		initialDeployment := &kappsapi.Deployment{}
-		glog.Infof("Get deployment %q", controllersDeploymentKey.Name)
-		err = wait.PollImmediate(1*time.Second, e2e.WaitShort, func() (bool, error) {
-			if err := client.Get(context.TODO(), controllersDeploymentKey, initialDeployment); err != nil {
-				glog.Errorf("error querying api for Deployment object: %v, retrying...", err)
-				return false, nil
-			}
-			return true, nil
-		})
+		deploymentName := "clusterapi-manager-controllers"
+		initialDeployment, err := getDeployment(client, deploymentName)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		g.By(fmt.Sprintf("checking deployment %q is available", controllersDeploymentKey.Name))
-		o.Expect(isDeploymentAvailable(client, controllersDeploymentKey.Name)).To(o.BeTrue())
+		g.By(fmt.Sprintf("checking deployment %q is available", deploymentName))
+		o.Expect(isDeploymentAvailable(client, deploymentName)).To(o.BeTrue())
 
-		g.By(fmt.Sprintf("deleting deployment %q", controllersDeploymentKey.Name))
-		err = wait.PollImmediate(1*time.Second, e2e.WaitShort, func() (bool, error) {
-			if err := client.Delete(context.TODO(), initialDeployment); err != nil {
-				glog.Errorf("error querying api for Deployment object: %v, retrying...", err)
-				return false, nil
-			}
-			return true, nil
-		})
+		g.By(fmt.Sprintf("deleting deployment %q", deploymentName))
+		err = deleteDeployment(client, initialDeployment)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		g.By(fmt.Sprintf("checking deployment %q is available again", controllersDeploymentKey.Name))
-		o.Expect(isDeploymentAvailable(client, controllersDeploymentKey.Name)).To(o.BeTrue())
+		g.By(fmt.Sprintf("checking deployment %q is available again", deploymentName))
+		o.Expect(isDeploymentAvailable(client, deploymentName)).To(o.BeTrue())
 	})
 
 })

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/operators/utils.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/operators/utils.go
@@ -2,6 +2,7 @@ package operators
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/golang/glog"
@@ -14,7 +15,7 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func isDeploymentAvailable(client runtimeclient.Client, name string) bool {
+func getDeployment(client runtimeclient.Client, name string) (*kappsapi.Deployment, error) {
 	key := types.NamespacedName{
 		Namespace: e2e.TestContext.MachineApiNamespace,
 		Name:      name,
@@ -23,19 +24,43 @@ func isDeploymentAvailable(client runtimeclient.Client, name string) bool {
 
 	if err := wait.PollImmediate(1*time.Second, e2e.WaitShort, func() (bool, error) {
 		if err := client.Get(context.TODO(), key, d); err != nil {
-			glog.Errorf("Error querying api for Deployment object: %v, retrying...", err)
+			glog.Errorf("Error querying api for Deployment object %q: %v, retrying...", name, err)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		return nil, fmt.Errorf("error getting deployment %q: %v", name, err)
+	}
+	return d, nil
+}
+
+func deleteDeployment(client runtimeclient.Client, deployment *kappsapi.Deployment) error {
+	return wait.PollImmediate(1*time.Second, e2e.WaitShort, func() (bool, error) {
+		if err := client.Delete(context.TODO(), deployment); err != nil {
+			glog.Errorf("error querying api for deployment object %q: %v, retrying...", deployment.Name, err)
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+func isDeploymentAvailable(client runtimeclient.Client, name string) bool {
+	if err := wait.PollImmediate(1*time.Second, e2e.WaitShort, func() (bool, error) {
+		d, err := getDeployment(client, name)
+		if err != nil {
+			glog.Errorf("Error getting deployment: %v", err)
 			return false, nil
 		}
 		if d.Status.AvailableReplicas < 1 {
 			glog.Errorf("Deployment %q is not available. Status: (replicas: %d, updated: %d, ready: %d, available: %d, unavailable: %d)", d.Name, d.Status.Replicas, d.Status.UpdatedReplicas, d.Status.ReadyReplicas, d.Status.AvailableReplicas, d.Status.UnavailableReplicas)
 			return false, nil
 		}
+		glog.Infof("Deployment %q is available. Status: (replicas: %d, updated: %d, ready: %d, available: %d, unavailable: %d)", d.Name, d.Status.Replicas, d.Status.UpdatedReplicas, d.Status.ReadyReplicas, d.Status.AvailableReplicas, d.Status.UnavailableReplicas)
 		return true, nil
 	}); err != nil {
 		glog.Errorf("Error checking isDeploymentAvailable: %v", err)
 		return false
 	}
-	glog.Infof("Deployment %q is available. Status: (replicas: %d, updated: %d, ready: %d, available: %d, unavailable: %d)", d.Name, d.Status.Replicas, d.Status.UpdatedReplicas, d.Status.ReadyReplicas, d.Status.AvailableReplicas, d.Status.UnavailableReplicas)
 	return true
 }
 

--- a/vendor/k8s.io/utils/LICENSE
+++ b/vendor/k8s.io/utils/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/k8s.io/utils/buffer/ring_growing.go
+++ b/vendor/k8s.io/utils/buffer/ring_growing.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buffer
+
+// RingGrowing is a growing ring buffer.
+// Not thread safe.
+type RingGrowing struct {
+	data     []interface{}
+	n        int // Size of Data
+	beg      int // First available element
+	readable int // Number of data items available
+}
+
+// NewRingGrowing constructs a new RingGrowing instance with provided parameters.
+func NewRingGrowing(initialSize int) *RingGrowing {
+	return &RingGrowing{
+		data: make([]interface{}, initialSize),
+		n:    initialSize,
+	}
+}
+
+// ReadOne reads (consumes) first item from the buffer if it is available, otherwise returns false.
+func (r *RingGrowing) ReadOne() (data interface{}, ok bool) {
+	if r.readable == 0 {
+		return nil, false
+	}
+	r.readable--
+	element := r.data[r.beg]
+	r.data[r.beg] = nil // Remove reference to the object to help GC
+	if r.beg == r.n-1 {
+		// Was the last element
+		r.beg = 0
+	} else {
+		r.beg++
+	}
+	return element, true
+}
+
+// WriteOne adds an item to the end of the buffer, growing it if it is full.
+func (r *RingGrowing) WriteOne(data interface{}) {
+	if r.readable == r.n {
+		// Time to grow
+		newN := r.n * 2
+		newData := make([]interface{}, newN)
+		to := r.beg + r.readable
+		if to <= r.n {
+			copy(newData, r.data[r.beg:to])
+		} else {
+			copied := copy(newData, r.data[r.beg:])
+			copy(newData[copied:], r.data[:(to%r.n)])
+		}
+		r.beg = 0
+		r.data = newData
+		r.n = newN
+	}
+	r.data[(r.readable+r.beg)%r.n] = data
+	r.readable++
+}

--- a/vendor/k8s.io/utils/clock/clock.go
+++ b/vendor/k8s.io/utils/clock/clock.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import "time"
+
+// Clock allows for injecting fake or real clocks into code that
+// needs to do arbitrary things based on time.
+type Clock interface {
+	Now() time.Time
+	Since(time.Time) time.Duration
+	After(d time.Duration) <-chan time.Time
+	NewTimer(d time.Duration) Timer
+	Sleep(d time.Duration)
+	Tick(d time.Duration) <-chan time.Time
+}
+
+var _ = Clock(RealClock{})
+
+// RealClock really calls time.Now()
+type RealClock struct{}
+
+// Now returns the current time.
+func (RealClock) Now() time.Time {
+	return time.Now()
+}
+
+// Since returns time since the specified timestamp.
+func (RealClock) Since(ts time.Time) time.Duration {
+	return time.Since(ts)
+}
+
+// After is the same as time.After(d).
+func (RealClock) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
+}
+
+// NewTimer is the same as time.NewTimer(d)
+func (RealClock) NewTimer(d time.Duration) Timer {
+	return &realTimer{
+		timer: time.NewTimer(d),
+	}
+}
+
+// Tick is the same as time.Tick(d)
+func (RealClock) Tick(d time.Duration) <-chan time.Time {
+	return time.Tick(d)
+}
+
+// Sleep is the same as time.Sleep(d)
+func (RealClock) Sleep(d time.Duration) {
+	time.Sleep(d)
+}
+
+// Timer allows for injecting fake or real timers into code that
+// needs to do arbitrary things based on time.
+type Timer interface {
+	C() <-chan time.Time
+	Stop() bool
+	Reset(d time.Duration) bool
+}
+
+var _ = Timer(&realTimer{})
+
+// realTimer is backed by an actual time.Timer.
+type realTimer struct {
+	timer *time.Timer
+}
+
+// C returns the underlying timer's channel.
+func (r *realTimer) C() <-chan time.Time {
+	return r.timer.C
+}
+
+// Stop calls Stop() on the underlying timer.
+func (r *realTimer) Stop() bool {
+	return r.timer.Stop()
+}
+
+// Reset calls Reset() on the underlying timer.
+func (r *realTimer) Reset(d time.Duration) bool {
+	return r.timer.Reset(d)
+}

--- a/vendor/k8s.io/utils/clock/testing/fake_clock.go
+++ b/vendor/k8s.io/utils/clock/testing/fake_clock.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+var (
+	_ = clock.Clock(&FakeClock{})
+	_ = clock.Clock(&IntervalClock{})
+)
+
+// FakeClock implements clock.Clock, but returns an arbitrary time.
+type FakeClock struct {
+	lock sync.RWMutex
+	time time.Time
+
+	// waiters are waiting for the fake time to pass their specified time
+	waiters []*fakeClockWaiter
+}
+
+type fakeClockWaiter struct {
+	targetTime    time.Time
+	stepInterval  time.Duration
+	skipIfBlocked bool
+	destChan      chan time.Time
+	fired         bool
+}
+
+// NewFakeClock constructs a fake clock set to the provided time.
+func NewFakeClock(t time.Time) *FakeClock {
+	return &FakeClock{
+		time: t,
+	}
+}
+
+// Now returns f's time.
+func (f *FakeClock) Now() time.Time {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	return f.time
+}
+
+// Since returns time since the time in f.
+func (f *FakeClock) Since(ts time.Time) time.Duration {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	return f.time.Sub(ts)
+}
+
+// After is the fake version of time.After(d).
+func (f *FakeClock) After(d time.Duration) <-chan time.Time {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	stopTime := f.time.Add(d)
+	ch := make(chan time.Time, 1) // Don't block!
+	f.waiters = append(f.waiters, &fakeClockWaiter{
+		targetTime: stopTime,
+		destChan:   ch,
+	})
+	return ch
+}
+
+// NewTimer constructs a fake timer, akin to time.NewTimer(d).
+func (f *FakeClock) NewTimer(d time.Duration) clock.Timer {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	stopTime := f.time.Add(d)
+	ch := make(chan time.Time, 1) // Don't block!
+	timer := &fakeTimer{
+		fakeClock: f,
+		waiter: fakeClockWaiter{
+			targetTime: stopTime,
+			destChan:   ch,
+		},
+	}
+	f.waiters = append(f.waiters, &timer.waiter)
+	return timer
+}
+
+// Tick constructs a fake ticker, akin to time.Tick
+func (f *FakeClock) Tick(d time.Duration) <-chan time.Time {
+	if d <= 0 {
+		return nil
+	}
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	tickTime := f.time.Add(d)
+	ch := make(chan time.Time, 1) // hold one tick
+	f.waiters = append(f.waiters, &fakeClockWaiter{
+		targetTime:    tickTime,
+		stepInterval:  d,
+		skipIfBlocked: true,
+		destChan:      ch,
+	})
+
+	return ch
+}
+
+// Step moves the clock by Duration and notifies anyone that's called After,
+// Tick, or NewTimer.
+func (f *FakeClock) Step(d time.Duration) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.setTimeLocked(f.time.Add(d))
+}
+
+// SetTime sets the time.
+func (f *FakeClock) SetTime(t time.Time) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.setTimeLocked(t)
+}
+
+// Actually changes the time and checks any waiters. f must be write-locked.
+func (f *FakeClock) setTimeLocked(t time.Time) {
+	f.time = t
+	newWaiters := make([]*fakeClockWaiter, 0, len(f.waiters))
+	for i := range f.waiters {
+		w := f.waiters[i]
+		if !w.targetTime.After(t) {
+
+			if w.skipIfBlocked {
+				select {
+				case w.destChan <- t:
+					w.fired = true
+				default:
+				}
+			} else {
+				w.destChan <- t
+				w.fired = true
+			}
+
+			if w.stepInterval > 0 {
+				for !w.targetTime.After(t) {
+					w.targetTime = w.targetTime.Add(w.stepInterval)
+				}
+				newWaiters = append(newWaiters, w)
+			}
+
+		} else {
+			newWaiters = append(newWaiters, f.waiters[i])
+		}
+	}
+	f.waiters = newWaiters
+}
+
+// HasWaiters returns true if After has been called on f but not yet satisfied (so you can
+// write race-free tests).
+func (f *FakeClock) HasWaiters() bool {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	return len(f.waiters) > 0
+}
+
+// Sleep is akin to time.Sleep
+func (f *FakeClock) Sleep(d time.Duration) {
+	f.Step(d)
+}
+
+// IntervalClock implements clock.Clock, but each invocation of Now steps the clock forward the specified duration
+type IntervalClock struct {
+	Time     time.Time
+	Duration time.Duration
+}
+
+// Now returns i's time.
+func (i *IntervalClock) Now() time.Time {
+	i.Time = i.Time.Add(i.Duration)
+	return i.Time
+}
+
+// Since returns time since the time in i.
+func (i *IntervalClock) Since(ts time.Time) time.Duration {
+	return i.Time.Sub(ts)
+}
+
+// After is unimplemented, will panic.
+// TODO: make interval clock use FakeClock so this can be implemented.
+func (*IntervalClock) After(d time.Duration) <-chan time.Time {
+	panic("IntervalClock doesn't implement After")
+}
+
+// NewTimer is unimplemented, will panic.
+// TODO: make interval clock use FakeClock so this can be implemented.
+func (*IntervalClock) NewTimer(d time.Duration) clock.Timer {
+	panic("IntervalClock doesn't implement NewTimer")
+}
+
+// Tick is unimplemented, will panic.
+// TODO: make interval clock use FakeClock so this can be implemented.
+func (*IntervalClock) Tick(d time.Duration) <-chan time.Time {
+	panic("IntervalClock doesn't implement Tick")
+}
+
+// Sleep is unimplemented, will panic.
+func (*IntervalClock) Sleep(d time.Duration) {
+	panic("IntervalClock doesn't implement Sleep")
+}
+
+var _ = clock.Timer(&fakeTimer{})
+
+// fakeTimer implements clock.Timer based on a FakeClock.
+type fakeTimer struct {
+	fakeClock *FakeClock
+	waiter    fakeClockWaiter
+}
+
+// C returns the channel that notifies when this timer has fired.
+func (f *fakeTimer) C() <-chan time.Time {
+	return f.waiter.destChan
+}
+
+// Stop stops the timer and returns true if the timer has not yet fired, or false otherwise.
+func (f *fakeTimer) Stop() bool {
+	f.fakeClock.lock.Lock()
+	defer f.fakeClock.lock.Unlock()
+
+	newWaiters := make([]*fakeClockWaiter, 0, len(f.fakeClock.waiters))
+	for i := range f.fakeClock.waiters {
+		w := f.fakeClock.waiters[i]
+		if w != &f.waiter {
+			newWaiters = append(newWaiters, w)
+		}
+	}
+
+	f.fakeClock.waiters = newWaiters
+
+	return !f.waiter.fired
+}
+
+// Reset resets the timer to the fake clock's "now" + d. It returns true if the timer has not yet
+// fired, or false otherwise.
+func (f *fakeTimer) Reset(d time.Duration) bool {
+	f.fakeClock.lock.Lock()
+	defer f.fakeClock.lock.Unlock()
+
+	active := !f.waiter.fired
+
+	f.waiter.fired = false
+	f.waiter.targetTime = f.fakeClock.time.Add(d)
+
+	var isWaiting bool
+	for i := range f.fakeClock.waiters {
+		w := f.fakeClock.waiters[i]
+		if w == &f.waiter {
+			isWaiting = true
+			break
+		}
+	}
+	if !isWaiting {
+		f.fakeClock.waiters = append(f.fakeClock.waiters, &f.waiter)
+	}
+
+	return active
+}

--- a/vendor/k8s.io/utils/diff/diff.go
+++ b/vendor/k8s.io/utils/diff/diff.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diff
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/davecgh/go-spew/spew"
+
+	"k8s.io/utils/field"
+)
+
+// StringDiff diffs a and b and returns a human readable diff.
+func StringDiff(a, b string) string {
+	ba := []byte(a)
+	bb := []byte(b)
+	out := []byte{}
+	i := 0
+	for ; i < len(ba) && i < len(bb); i++ {
+		if ba[i] != bb[i] {
+			break
+		}
+		out = append(out, ba[i])
+	}
+	out = append(out, []byte("\n\nA: ")...)
+	out = append(out, ba[i:]...)
+	out = append(out, []byte("\n\nB: ")...)
+	out = append(out, bb[i:]...)
+	out = append(out, []byte("\n\n")...)
+	return string(out)
+}
+
+// ObjectDiff writes the two objects out as JSON and prints out the identical part of
+// the objects followed by the remaining part of 'a' and finally the remaining part of 'b'.
+// For debugging tests.
+func ObjectDiff(a, b interface{}) string {
+	ab, err := json.Marshal(a)
+	if err != nil {
+		panic(fmt.Sprintf("a: %v", err))
+	}
+	bb, err := json.Marshal(b)
+	if err != nil {
+		panic(fmt.Sprintf("b: %v", err))
+	}
+	return StringDiff(string(ab), string(bb))
+}
+
+// ObjectGoPrintDiff is like ObjectDiff, but uses go-spew to print the objects,
+// which shows absolutely everything by recursing into every single pointer
+// (go's %#v formatters OTOH stop at a certain point). This is needed when you
+// can't figure out why reflect.DeepEqual is returning false and nothing is
+// showing you differences. This will.
+func ObjectGoPrintDiff(a, b interface{}) string {
+	s := spew.ConfigState{DisableMethods: true}
+	return StringDiff(
+		s.Sprintf("%#v", a),
+		s.Sprintf("%#v", b),
+	)
+}
+
+// ObjectReflectDiff returns a diff computed through reflection, without serializing to JSON.
+func ObjectReflectDiff(a, b interface{}) string {
+	vA, vB := reflect.ValueOf(a), reflect.ValueOf(b)
+	if vA.Type() != vB.Type() {
+		return fmt.Sprintf("type A %T and type B %T do not match", a, b)
+	}
+	diffs := objectReflectDiff(field.NewPath("object"), vA, vB)
+	if len(diffs) == 0 {
+		return "<no diffs>"
+	}
+	out := []string{""}
+	for _, d := range diffs {
+		elidedA, elidedB := limit(d.a, d.b, 80)
+		out = append(out,
+			fmt.Sprintf("%s:", d.path),
+			fmt.Sprintf("  a: %s", elidedA),
+			fmt.Sprintf("  b: %s", elidedB),
+		)
+	}
+	return strings.Join(out, "\n")
+}
+
+// limit:
+// 1. stringifies aObj and bObj
+// 2. elides identical prefixes if either is too long
+// 3. elides remaining content from the end if either is too long
+func limit(aObj, bObj interface{}, max int) (string, string) {
+	elidedPrefix := ""
+	elidedASuffix := ""
+	elidedBSuffix := ""
+	a, b := fmt.Sprintf("%#v", aObj), fmt.Sprintf("%#v", bObj)
+
+	if aObj != nil && bObj != nil {
+		if aType, bType := fmt.Sprintf("%T", aObj), fmt.Sprintf("%T", bObj); aType != bType {
+			a = fmt.Sprintf("%s (%s)", a, aType)
+			b = fmt.Sprintf("%s (%s)", b, bType)
+		}
+	}
+
+	for {
+		switch {
+		case len(a) > max && len(a) > 4 && len(b) > 4 && a[:4] == b[:4]:
+			// a is too long, b has data, and the first several characters are the same
+			elidedPrefix = "..."
+			a = a[2:]
+			b = b[2:]
+
+		case len(b) > max && len(b) > 4 && len(a) > 4 && a[:4] == b[:4]:
+			// b is too long, a has data, and the first several characters are the same
+			elidedPrefix = "..."
+			a = a[2:]
+			b = b[2:]
+
+		case len(a) > max:
+			a = a[:max]
+			elidedASuffix = "..."
+
+		case len(b) > max:
+			b = b[:max]
+			elidedBSuffix = "..."
+
+		default:
+			// both are short enough
+			return elidedPrefix + a + elidedASuffix, elidedPrefix + b + elidedBSuffix
+		}
+	}
+}
+
+func public(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	return s[:1] == strings.ToUpper(s[:1])
+}
+
+type diff struct {
+	path *field.Path
+	a, b interface{}
+}
+
+type orderedDiffs []diff
+
+func (d orderedDiffs) Len() int      { return len(d) }
+func (d orderedDiffs) Swap(i, j int) { d[i], d[j] = d[j], d[i] }
+func (d orderedDiffs) Less(i, j int) bool {
+	a, b := d[i].path.String(), d[j].path.String()
+	if a < b {
+		return true
+	}
+	return false
+}
+
+func objectReflectDiff(path *field.Path, a, b reflect.Value) []diff {
+	switch a.Type().Kind() {
+	case reflect.Struct:
+		var changes []diff
+		for i := 0; i < a.Type().NumField(); i++ {
+			if !public(a.Type().Field(i).Name) {
+				if reflect.DeepEqual(a.Interface(), b.Interface()) {
+					continue
+				}
+				return []diff{{path: path, a: fmt.Sprintf("%#v", a), b: fmt.Sprintf("%#v", b)}}
+			}
+			if sub := objectReflectDiff(path.Child(a.Type().Field(i).Name), a.Field(i), b.Field(i)); len(sub) > 0 {
+				changes = append(changes, sub...)
+			}
+		}
+		return changes
+	case reflect.Ptr, reflect.Interface:
+		if a.IsNil() || b.IsNil() {
+			switch {
+			case a.IsNil() && b.IsNil():
+				return nil
+			case a.IsNil():
+				return []diff{{path: path, a: nil, b: b.Interface()}}
+			default:
+				return []diff{{path: path, a: a.Interface(), b: nil}}
+			}
+		}
+		return objectReflectDiff(path, a.Elem(), b.Elem())
+	case reflect.Chan:
+		if !reflect.DeepEqual(a.Interface(), b.Interface()) {
+			return []diff{{path: path, a: a.Interface(), b: b.Interface()}}
+		}
+		return nil
+	case reflect.Slice:
+		lA, lB := a.Len(), b.Len()
+		l := lA
+		if lB < lA {
+			l = lB
+		}
+		if lA == lB && lA == 0 {
+			if a.IsNil() != b.IsNil() {
+				return []diff{{path: path, a: a.Interface(), b: b.Interface()}}
+			}
+			return nil
+		}
+		var diffs []diff
+		for i := 0; i < l; i++ {
+			if !reflect.DeepEqual(a.Index(i), b.Index(i)) {
+				diffs = append(diffs, objectReflectDiff(path.Index(i), a.Index(i), b.Index(i))...)
+			}
+		}
+		for i := l; i < lA; i++ {
+			diffs = append(diffs, diff{path: path.Index(i), a: a.Index(i), b: nil})
+		}
+		for i := l; i < lB; i++ {
+			diffs = append(diffs, diff{path: path.Index(i), a: nil, b: b.Index(i)})
+		}
+		return diffs
+	case reflect.Map:
+		if reflect.DeepEqual(a.Interface(), b.Interface()) {
+			return nil
+		}
+		aKeys := make(map[interface{}]interface{})
+		for _, key := range a.MapKeys() {
+			aKeys[key.Interface()] = a.MapIndex(key).Interface()
+		}
+		var missing []diff
+		for _, key := range b.MapKeys() {
+			if _, ok := aKeys[key.Interface()]; ok {
+				delete(aKeys, key.Interface())
+				if reflect.DeepEqual(a.MapIndex(key).Interface(), b.MapIndex(key).Interface()) {
+					continue
+				}
+				missing = append(missing, objectReflectDiff(path.Key(fmt.Sprintf("%s", key.Interface())), a.MapIndex(key), b.MapIndex(key))...)
+				continue
+			}
+			missing = append(missing, diff{path: path.Key(fmt.Sprintf("%s", key.Interface())), a: nil, b: b.MapIndex(key).Interface()})
+		}
+		for key, value := range aKeys {
+			missing = append(missing, diff{path: path.Key(fmt.Sprintf("%s", key)), a: value, b: nil})
+		}
+		if len(missing) == 0 {
+			missing = append(missing, diff{path: path, a: a.Interface(), b: b.Interface()})
+		}
+		sort.Sort(orderedDiffs(missing))
+		return missing
+	default:
+		if reflect.DeepEqual(a.Interface(), b.Interface()) {
+			return nil
+		}
+		if !a.CanInterface() {
+			return []diff{{path: path, a: fmt.Sprintf("%#v", a), b: fmt.Sprintf("%#v", b)}}
+		}
+		return []diff{{path: path, a: a.Interface(), b: b.Interface()}}
+	}
+}
+
+// ObjectGoPrintSideBySide prints a and b as textual dumps side by side,
+// enabling easy visual scanning for mismatches.
+func ObjectGoPrintSideBySide(a, b interface{}) string {
+	s := spew.ConfigState{
+		Indent: " ",
+		// Extra deep spew.
+		DisableMethods: true,
+	}
+	sA := s.Sdump(a)
+	sB := s.Sdump(b)
+
+	linesA := strings.Split(sA, "\n")
+	linesB := strings.Split(sB, "\n")
+	width := 0
+	for _, s := range linesA {
+		l := len(s)
+		if l > width {
+			width = l
+		}
+	}
+	for _, s := range linesB {
+		l := len(s)
+		if l > width {
+			width = l
+		}
+	}
+	buf := &bytes.Buffer{}
+	w := tabwriter.NewWriter(buf, width, 0, 1, ' ', 0)
+	max := len(linesA)
+	if len(linesB) > max {
+		max = len(linesB)
+	}
+	for i := 0; i < max; i++ {
+		var a, b string
+		if i < len(linesA) {
+			a = linesA[i]
+		}
+		if i < len(linesB) {
+			b = linesB[i]
+		}
+		fmt.Fprintf(w, "%s\t%s\n", a, b)
+	}
+	w.Flush()
+	return buf.String()
+}

--- a/vendor/k8s.io/utils/exec/doc.go
+++ b/vendor/k8s.io/utils/exec/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package exec provides an injectable interface and implementations for running commands.
+package exec // import "k8s.io/utils/exec"

--- a/vendor/k8s.io/utils/exec/exec.go
+++ b/vendor/k8s.io/utils/exec/exec.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"context"
+	"io"
+	osexec "os/exec"
+	"syscall"
+	"time"
+)
+
+// ErrExecutableNotFound is returned if the executable is not found.
+var ErrExecutableNotFound = osexec.ErrNotFound
+
+// Interface is an interface that presents a subset of the os/exec API. Use this
+// when you want to inject fakeable/mockable exec behavior.
+type Interface interface {
+	// Command returns a Cmd instance which can be used to run a single command.
+	// This follows the pattern of package os/exec.
+	Command(cmd string, args ...string) Cmd
+
+	// CommandContext returns a Cmd instance which can be used to run a single command.
+	//
+	// The provided context is used to kill the process if the context becomes done
+	// before the command completes on its own. For example, a timeout can be set in
+	// the context.
+	CommandContext(ctx context.Context, cmd string, args ...string) Cmd
+
+	// LookPath wraps os/exec.LookPath
+	LookPath(file string) (string, error)
+}
+
+// Cmd is an interface that presents an API that is very similar to Cmd from os/exec.
+// As more functionality is needed, this can grow. Since Cmd is a struct, we will have
+// to replace fields with get/set method pairs.
+type Cmd interface {
+	// Run runs the command to the completion.
+	Run() error
+	// CombinedOutput runs the command and returns its combined standard output
+	// and standard error. This follows the pattern of package os/exec.
+	CombinedOutput() ([]byte, error)
+	// Output runs the command and returns standard output, but not standard err
+	Output() ([]byte, error)
+	SetDir(dir string)
+	SetStdin(in io.Reader)
+	SetStdout(out io.Writer)
+	SetStderr(out io.Writer)
+	SetEnv(env []string)
+
+	// StdoutPipe and StderrPipe for getting the process' Stdout and Stderr as
+	// Readers
+	StdoutPipe() (io.ReadCloser, error)
+	StderrPipe() (io.ReadCloser, error)
+
+	// Start and Wait are for running a process non-blocking
+	Start() error
+	Wait() error
+
+	// Stops the command by sending SIGTERM. It is not guaranteed the
+	// process will stop before this function returns. If the process is not
+	// responding, an internal timer function will send a SIGKILL to force
+	// terminate after 10 seconds.
+	Stop()
+}
+
+// ExitError is an interface that presents an API similar to os.ProcessState, which is
+// what ExitError from os/exec is. This is designed to make testing a bit easier and
+// probably loses some of the cross-platform properties of the underlying library.
+type ExitError interface {
+	String() string
+	Error() string
+	Exited() bool
+	ExitStatus() int
+}
+
+// Implements Interface in terms of really exec()ing.
+type executor struct{}
+
+// New returns a new Interface which will os/exec to run commands.
+func New() Interface {
+	return &executor{}
+}
+
+// Command is part of the Interface interface.
+func (executor *executor) Command(cmd string, args ...string) Cmd {
+	return (*cmdWrapper)(osexec.Command(cmd, args...))
+}
+
+// CommandContext is part of the Interface interface.
+func (executor *executor) CommandContext(ctx context.Context, cmd string, args ...string) Cmd {
+	return (*cmdWrapper)(osexec.CommandContext(ctx, cmd, args...))
+}
+
+// LookPath is part of the Interface interface
+func (executor *executor) LookPath(file string) (string, error) {
+	return osexec.LookPath(file)
+}
+
+// Wraps exec.Cmd so we can capture errors.
+type cmdWrapper osexec.Cmd
+
+var _ Cmd = &cmdWrapper{}
+
+func (cmd *cmdWrapper) SetDir(dir string) {
+	cmd.Dir = dir
+}
+
+func (cmd *cmdWrapper) SetStdin(in io.Reader) {
+	cmd.Stdin = in
+}
+
+func (cmd *cmdWrapper) SetStdout(out io.Writer) {
+	cmd.Stdout = out
+}
+
+func (cmd *cmdWrapper) SetStderr(out io.Writer) {
+	cmd.Stderr = out
+}
+
+func (cmd *cmdWrapper) SetEnv(env []string) {
+	cmd.Env = env
+}
+
+func (cmd *cmdWrapper) StdoutPipe() (io.ReadCloser, error) {
+	r, err := (*osexec.Cmd)(cmd).StdoutPipe()
+	return r, handleError(err)
+}
+
+func (cmd *cmdWrapper) StderrPipe() (io.ReadCloser, error) {
+	r, err := (*osexec.Cmd)(cmd).StderrPipe()
+	return r, handleError(err)
+}
+
+func (cmd *cmdWrapper) Start() error {
+	err := (*osexec.Cmd)(cmd).Start()
+	return handleError(err)
+}
+
+func (cmd *cmdWrapper) Wait() error {
+	err := (*osexec.Cmd)(cmd).Wait()
+	return handleError(err)
+}
+
+// Run is part of the Cmd interface.
+func (cmd *cmdWrapper) Run() error {
+	err := (*osexec.Cmd)(cmd).Run()
+	return handleError(err)
+}
+
+// CombinedOutput is part of the Cmd interface.
+func (cmd *cmdWrapper) CombinedOutput() ([]byte, error) {
+	out, err := (*osexec.Cmd)(cmd).CombinedOutput()
+	return out, handleError(err)
+}
+
+func (cmd *cmdWrapper) Output() ([]byte, error) {
+	out, err := (*osexec.Cmd)(cmd).Output()
+	return out, handleError(err)
+}
+
+// Stop is part of the Cmd interface.
+func (cmd *cmdWrapper) Stop() {
+	c := (*osexec.Cmd)(cmd)
+
+	if c.Process == nil {
+		return
+	}
+
+	c.Process.Signal(syscall.SIGTERM)
+
+	time.AfterFunc(10*time.Second, func() {
+		if !c.ProcessState.Exited() {
+			c.Process.Signal(syscall.SIGKILL)
+		}
+	})
+}
+
+func handleError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch e := err.(type) {
+	case *osexec.ExitError:
+		return &ExitErrorWrapper{e}
+	case *osexec.Error:
+		if e.Err == osexec.ErrNotFound {
+			return ErrExecutableNotFound
+		}
+	}
+
+	return err
+}
+
+// ExitErrorWrapper is an implementation of ExitError in terms of os/exec ExitError.
+// Note: standard exec.ExitError is type *os.ProcessState, which already implements Exited().
+type ExitErrorWrapper struct {
+	*osexec.ExitError
+}
+
+var _ ExitError = &ExitErrorWrapper{}
+
+// ExitStatus is part of the ExitError interface.
+func (eew ExitErrorWrapper) ExitStatus() int {
+	ws, ok := eew.Sys().(syscall.WaitStatus)
+	if !ok {
+		panic("can't call ExitStatus() on a non-WaitStatus exitErrorWrapper")
+	}
+	return ws.ExitStatus()
+}
+
+// CodeExitError is an implementation of ExitError consisting of an error object
+// and an exit code (the upper bits of os.exec.ExitStatus).
+type CodeExitError struct {
+	Err  error
+	Code int
+}
+
+var _ ExitError = CodeExitError{}
+
+func (e CodeExitError) Error() string {
+	return e.Err.Error()
+}
+
+func (e CodeExitError) String() string {
+	return e.Err.Error()
+}
+
+// Exited is to check if the process has finished
+func (e CodeExitError) Exited() bool {
+	return true
+}
+
+// ExitStatus is for checking the error code
+func (e CodeExitError) ExitStatus() int {
+	return e.Code
+}

--- a/vendor/k8s.io/utils/exec/testing/fake_exec.go
+++ b/vendor/k8s.io/utils/exec/testing/fake_exec.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testingexec
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"k8s.io/utils/exec"
+)
+
+// FakeExec is a simple scripted Interface type.
+type FakeExec struct {
+	CommandScript []FakeCommandAction
+	CommandCalls  int
+	LookPathFunc  func(string) (string, error)
+}
+
+var _ exec.Interface = &FakeExec{}
+
+// FakeCommandAction is the function to be executed
+type FakeCommandAction func(cmd string, args ...string) exec.Cmd
+
+// Command is to track the commands that are executed
+func (fake *FakeExec) Command(cmd string, args ...string) exec.Cmd {
+	if fake.CommandCalls > len(fake.CommandScript)-1 {
+		panic(fmt.Sprintf("ran out of Command() actions. Could not handle command [%d]: %s args: %v", fake.CommandCalls, cmd, args))
+	}
+	i := fake.CommandCalls
+	fake.CommandCalls++
+	return fake.CommandScript[i](cmd, args...)
+}
+
+// CommandContext wraps arguments into exec.Cmd
+func (fake *FakeExec) CommandContext(ctx context.Context, cmd string, args ...string) exec.Cmd {
+	return fake.Command(cmd, args...)
+}
+
+// LookPath is for finding the path of a file
+func (fake *FakeExec) LookPath(file string) (string, error) {
+	return fake.LookPathFunc(file)
+}
+
+// FakeCmd is a simple scripted Cmd type.
+type FakeCmd struct {
+	Argv                 []string
+	CombinedOutputScript []FakeCombinedOutputAction
+	CombinedOutputCalls  int
+	CombinedOutputLog    [][]string
+	RunScript            []FakeRunAction
+	RunCalls             int
+	RunLog               [][]string
+	Dirs                 []string
+	Stdin                io.Reader
+	Stdout               io.Writer
+	Stderr               io.Writer
+	Env                  []string
+	StdoutPipeResponse   FakeStdIOPipeResponse
+	StderrPipeResponse   FakeStdIOPipeResponse
+	WaitResponse         error
+	StartResponse        error
+}
+
+var _ exec.Cmd = &FakeCmd{}
+
+// InitFakeCmd is for creating a fake exec.Cmd
+func InitFakeCmd(fake *FakeCmd, cmd string, args ...string) exec.Cmd {
+	fake.Argv = append([]string{cmd}, args...)
+	return fake
+}
+
+// FakeStdIOPipeResponse holds responses to use as fakes for the StdoutPipe and
+// StderrPipe method calls
+type FakeStdIOPipeResponse struct {
+	ReadCloser io.ReadCloser
+	Error      error
+}
+
+// FakeCombinedOutputAction is a function type
+type FakeCombinedOutputAction func() ([]byte, error)
+
+// FakeRunAction is a function type
+type FakeRunAction func() ([]byte, []byte, error)
+
+// SetDir sets the directory
+func (fake *FakeCmd) SetDir(dir string) {
+	fake.Dirs = append(fake.Dirs, dir)
+}
+
+// SetStdin sets the stdin
+func (fake *FakeCmd) SetStdin(in io.Reader) {
+	fake.Stdin = in
+}
+
+// SetStdout sets the stdout
+func (fake *FakeCmd) SetStdout(out io.Writer) {
+	fake.Stdout = out
+}
+
+// SetStderr sets the stderr
+func (fake *FakeCmd) SetStderr(out io.Writer) {
+	fake.Stderr = out
+}
+
+// SetEnv sets the environment variables
+func (fake *FakeCmd) SetEnv(env []string) {
+	fake.Env = env
+}
+
+// StdoutPipe returns an injected ReadCloser & error (via StdoutPipeResponse)
+// to be able to inject an output stream on Stdout
+func (fake *FakeCmd) StdoutPipe() (io.ReadCloser, error) {
+	return fake.StdoutPipeResponse.ReadCloser, fake.StdoutPipeResponse.Error
+}
+
+// StderrPipe returns an injected ReadCloser & error (via StderrPipeResponse)
+// to be able to inject an output stream on Stderr
+func (fake *FakeCmd) StderrPipe() (io.ReadCloser, error) {
+	return fake.StderrPipeResponse.ReadCloser, fake.StderrPipeResponse.Error
+}
+
+// Start mimicks starting the process (in the background) and returns the
+// injected StartResponse
+func (fake *FakeCmd) Start() error {
+	return fake.StartResponse
+}
+
+// Wait mimicks waiting for the process to exit returns the
+// injected WaitResponse
+func (fake *FakeCmd) Wait() error {
+	return fake.WaitResponse
+}
+
+// Run sets runs the command
+func (fake *FakeCmd) Run() error {
+	if fake.RunCalls > len(fake.RunScript)-1 {
+		panic("ran out of Run() actions")
+	}
+	if fake.RunLog == nil {
+		fake.RunLog = [][]string{}
+	}
+	i := fake.RunCalls
+	fake.RunLog = append(fake.RunLog, append([]string{}, fake.Argv...))
+	fake.RunCalls++
+	stdout, stderr, err := fake.RunScript[i]()
+	if stdout != nil {
+		fake.Stdout.Write(stdout)
+	}
+	if stderr != nil {
+		fake.Stderr.Write(stderr)
+	}
+	return err
+}
+
+// CombinedOutput returns the output from the command
+func (fake *FakeCmd) CombinedOutput() ([]byte, error) {
+	if fake.CombinedOutputCalls > len(fake.CombinedOutputScript)-1 {
+		panic("ran out of CombinedOutput() actions")
+	}
+	if fake.CombinedOutputLog == nil {
+		fake.CombinedOutputLog = [][]string{}
+	}
+	i := fake.CombinedOutputCalls
+	fake.CombinedOutputLog = append(fake.CombinedOutputLog, append([]string{}, fake.Argv...))
+	fake.CombinedOutputCalls++
+	return fake.CombinedOutputScript[i]()
+}
+
+// Output is the response from the command
+func (fake *FakeCmd) Output() ([]byte, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+// Stop is to stop the process
+func (fake *FakeCmd) Stop() {
+	// no-op
+}
+
+// FakeExitError is a simple fake ExitError type.
+type FakeExitError struct {
+	Status int
+}
+
+var _ exec.ExitError = FakeExitError{}
+
+func (fake FakeExitError) String() string {
+	return fmt.Sprintf("exit %d", fake.Status)
+}
+
+func (fake FakeExitError) Error() string {
+	return fake.String()
+}
+
+// Exited always returns true
+func (fake FakeExitError) Exited() bool {
+	return true
+}
+
+// ExitStatus returns the fake status
+func (fake FakeExitError) ExitStatus() int {
+	return fake.Status
+}

--- a/vendor/k8s.io/utils/field/path.go
+++ b/vendor/k8s.io/utils/field/path.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package field
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+)
+
+// Path represents the path from some root to a particular field.
+type Path struct {
+	name   string // the name of this field or "" if this is an index
+	index  string // if name == "", this is a subscript (index or map key) of the previous element
+	parent *Path  // nil if this is the root element
+}
+
+// NewPath creates a root Path object.
+func NewPath(name string, moreNames ...string) *Path {
+	r := &Path{name: name, parent: nil}
+	for _, anotherName := range moreNames {
+		r = &Path{name: anotherName, parent: r}
+	}
+	return r
+}
+
+// Root returns the root element of this Path.
+func (p *Path) Root() *Path {
+	for ; p.parent != nil; p = p.parent {
+		// Do nothing.
+	}
+	return p
+}
+
+// Child creates a new Path that is a child of the method receiver.
+func (p *Path) Child(name string, moreNames ...string) *Path {
+	r := NewPath(name, moreNames...)
+	r.Root().parent = p
+	return r
+}
+
+// Index indicates that the previous Path is to be subscripted by an int.
+// This sets the same underlying value as Key.
+func (p *Path) Index(index int) *Path {
+	return &Path{index: strconv.Itoa(index), parent: p}
+}
+
+// Key indicates that the previous Path is to be subscripted by a string.
+// This sets the same underlying value as Index.
+func (p *Path) Key(key string) *Path {
+	return &Path{index: key, parent: p}
+}
+
+// String produces a string representation of the Path.
+func (p *Path) String() string {
+	// make a slice to iterate
+	elems := []*Path{}
+	for ; p != nil; p = p.parent {
+		elems = append(elems, p)
+	}
+
+	// iterate, but it has to be backwards
+	buf := bytes.NewBuffer(nil)
+	for i := range elems {
+		p := elems[len(elems)-1-i]
+		if p.parent != nil && len(p.name) > 0 {
+			// This is either the root or it is a subscript.
+			buf.WriteString(".")
+		}
+		if len(p.name) > 0 {
+			buf.WriteString(p.name)
+		} else {
+			fmt.Fprintf(buf, "[%s]", p.index)
+		}
+	}
+	return buf.String()
+}

--- a/vendor/k8s.io/utils/integer/integer.go
+++ b/vendor/k8s.io/utils/integer/integer.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integer
+
+// IntMax returns the maximum of the params
+func IntMax(a, b int) int {
+	if b > a {
+		return b
+	}
+	return a
+}
+
+// IntMin returns the minimum of the params
+func IntMin(a, b int) int {
+	if b < a {
+		return b
+	}
+	return a
+}
+
+// Int32Max returns the maximum of the params
+func Int32Max(a, b int32) int32 {
+	if b > a {
+		return b
+	}
+	return a
+}
+
+// Int32Min returns the minimum of the params
+func Int32Min(a, b int32) int32 {
+	if b < a {
+		return b
+	}
+	return a
+}
+
+// Int64Max returns the maximum of the params
+func Int64Max(a, b int64) int64 {
+	if b > a {
+		return b
+	}
+	return a
+}
+
+// Int64Min returns the minimum of the params
+func Int64Min(a, b int64) int64 {
+	if b < a {
+		return b
+	}
+	return a
+}
+
+// RoundToInt32 rounds floats into integer numbers.
+func RoundToInt32(a float64) int32 {
+	if a < 0 {
+		return int32(a - 0.5)
+	}
+	return int32(a + 0.5)
+}

--- a/vendor/k8s.io/utils/io/consistentread.go
+++ b/vendor/k8s.io/utils/io/consistentread.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+)
+
+// ConsistentRead repeatedly reads a file until it gets the same content twice.
+// This is useful when reading files in /proc that are larger than page size
+// and kernel may modify them between individual read() syscalls.
+func ConsistentRead(filename string, attempts int) ([]byte, error) {
+	return consistentReadSync(filename, attempts, nil)
+}
+
+// consistentReadSync is the main functionality of ConsistentRead but
+// introduces a sync callback that can be used by the tests to mutate the file
+// from which the test data is being read
+func consistentReadSync(filename string, attempts int, sync func(int)) ([]byte, error) {
+	oldContent, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < attempts; i++ {
+		if sync != nil {
+			sync(i)
+		}
+		newContent, err := ioutil.ReadFile(filename)
+		if err != nil {
+			return nil, err
+		}
+		if bytes.Compare(oldContent, newContent) == 0 {
+			return newContent, nil
+		}
+		// Files are different, continue reading
+		oldContent = newContent
+	}
+	return nil, fmt.Errorf("could not get consistent content of %s after %d attempts", filename, attempts)
+}

--- a/vendor/k8s.io/utils/keymutex/hashed.go
+++ b/vendor/k8s.io/utils/keymutex/hashed.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keymutex
+
+import (
+	"hash/fnv"
+	"runtime"
+	"sync"
+)
+
+// NewHashed returns a new instance of KeyMutex which hashes arbitrary keys to
+// a fixed set of locks. `n` specifies number of locks, if n <= 0, we use
+// number of cpus.
+// Note that because it uses fixed set of locks, different keys may share same
+// lock, so it's possible to wait on same lock.
+func NewHashed(n int) KeyMutex {
+	if n <= 0 {
+		n = runtime.NumCPU()
+	}
+	return &hashedKeyMutex{
+		mutexes: make([]sync.Mutex, n),
+	}
+}
+
+type hashedKeyMutex struct {
+	mutexes []sync.Mutex
+}
+
+// Acquires a lock associated with the specified ID.
+func (km *hashedKeyMutex) LockKey(id string) {
+	km.mutexes[km.hash(id)%uint32(len(km.mutexes))].Lock()
+}
+
+// Releases the lock associated with the specified ID.
+func (km *hashedKeyMutex) UnlockKey(id string) error {
+	km.mutexes[km.hash(id)%uint32(len(km.mutexes))].Unlock()
+	return nil
+}
+
+func (km *hashedKeyMutex) hash(id string) uint32 {
+	h := fnv.New32a()
+	h.Write([]byte(id))
+	return h.Sum32()
+}

--- a/vendor/k8s.io/utils/keymutex/keymutex.go
+++ b/vendor/k8s.io/utils/keymutex/keymutex.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keymutex
+
+// KeyMutex is a thread-safe interface for acquiring locks on arbitrary strings.
+type KeyMutex interface {
+	// Acquires a lock associated with the specified ID, creates the lock if one doesn't already exist.
+	LockKey(id string)
+
+	// Releases the lock associated with the specified ID.
+	// Returns an error if the specified ID doesn't exist.
+	UnlockKey(id string) error
+}

--- a/vendor/k8s.io/utils/net/ipnet.go
+++ b/vendor/k8s.io/utils/net/ipnet.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"net"
+	"strings"
+)
+
+// IPNetSet maps string to net.IPNet.
+type IPNetSet map[string]*net.IPNet
+
+// ParseIPNets parses string slice to IPNetSet.
+func ParseIPNets(specs ...string) (IPNetSet, error) {
+	ipnetset := make(IPNetSet)
+	for _, spec := range specs {
+		spec = strings.TrimSpace(spec)
+		_, ipnet, err := net.ParseCIDR(spec)
+		if err != nil {
+			return nil, err
+		}
+		k := ipnet.String() // In case of normalization
+		ipnetset[k] = ipnet
+	}
+	return ipnetset, nil
+}
+
+// Insert adds items to the set.
+func (s IPNetSet) Insert(items ...*net.IPNet) {
+	for _, item := range items {
+		s[item.String()] = item
+	}
+}
+
+// Delete removes all items from the set.
+func (s IPNetSet) Delete(items ...*net.IPNet) {
+	for _, item := range items {
+		delete(s, item.String())
+	}
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s IPNetSet) Has(item *net.IPNet) bool {
+	_, contained := s[item.String()]
+	return contained
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s IPNetSet) HasAll(items ...*net.IPNet) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Difference returns a set of objects that are not in s2
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s IPNetSet) Difference(s2 IPNetSet) IPNetSet {
+	result := make(IPNetSet)
+	for k, i := range s {
+		_, found := s2[k]
+		if found {
+			continue
+		}
+		result[k] = i
+	}
+	return result
+}
+
+// StringSlice returns a []string with the String representation of each element in the set.
+// Order is undefined.
+func (s IPNetSet) StringSlice() []string {
+	a := make([]string, 0, len(s))
+	for k := range s {
+		a = append(a, k)
+	}
+	return a
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s IPNetSet) IsSuperset(s2 IPNetSet) bool {
+	for k := range s2 {
+		_, found := s[k]
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s IPNetSet) Equal(s2 IPNetSet) bool {
+	return len(s) == len(s2) && s.IsSuperset(s2)
+}
+
+// Len returns the size of the set.
+func (s IPNetSet) Len() int {
+	return len(s)
+}

--- a/vendor/k8s.io/utils/net/net.go
+++ b/vendor/k8s.io/utils/net/net.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import "net"
+
+// IsIPv6 returns if netIP is IPv6.
+func IsIPv6(netIP net.IP) bool {
+	return netIP != nil && netIP.To4() == nil
+}
+
+// IsIPv6String returns if ip is IPv6.
+func IsIPv6String(ip string) bool {
+	netIP := net.ParseIP(ip)
+	return IsIPv6(netIP)
+}
+
+// IsIPv6CIDRString returns if cidr is IPv6.
+// This assumes cidr is a valid CIDR.
+func IsIPv6CIDRString(cidr string) bool {
+	ip, _, _ := net.ParseCIDR(cidr)
+	return IsIPv6(ip)
+}

--- a/vendor/k8s.io/utils/nsenter/nsenter.go
+++ b/vendor/k8s.io/utils/nsenter/nsenter.go
@@ -1,0 +1,258 @@
+// +build linux
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nsenter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/klog"
+	"k8s.io/utils/exec"
+)
+
+const (
+	// DefaultHostRootFsPath is path to host's filesystem mounted into container
+	// with kubelet.
+	DefaultHostRootFsPath = "/rootfs"
+	// mountNsPath is the default mount namespace of the host
+	mountNsPath = "/proc/1/ns/mnt"
+	// nsenterPath is the default nsenter command
+	nsenterPath = "nsenter"
+)
+
+// Nsenter is a type alias for backward compatibility
+type Nsenter = NSEnter
+
+// NSEnter is part of experimental support for running the kubelet
+// in a container.
+//
+// NSEnter requires:
+//
+// 1.  Docker >= 1.6 due to the dependency on the slave propagation mode
+//     of the bind-mount of the kubelet root directory in the container.
+//     Docker 1.5 used a private propagation mode for bind-mounts, so mounts
+//     performed in the host's mount namespace do not propagate out to the
+//     bind-mount in this docker version.
+// 2.  The host's root filesystem must be available at /rootfs
+// 3.  The nsenter binary must be on the Kubelet process' PATH in the container's
+//     filesystem.
+// 4.  The Kubelet process must have CAP_SYS_ADMIN (required by nsenter); at
+//     the present, this effectively means that the kubelet is running in a
+//     privileged container.
+// 5.  The volume path used by the Kubelet must be the same inside and outside
+//     the container and be writable by the container (to initialize volume)
+//     contents. TODO: remove this requirement.
+// 6.  The host image must have "mount", "findmnt", "umount", "stat", "touch",
+//     "mkdir", "ls", "sh" and "chmod" binaries in /bin, /usr/sbin, or /usr/bin
+// 7.  The host image should have systemd-run in /bin, /usr/sbin, or /usr/bin if
+//     systemd is installed/enabled in the operating system.
+// For more information about mount propagation modes, see:
+//   https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt
+type NSEnter struct {
+	// a map of commands to their paths on the host filesystem
+	paths map[string]string
+
+	// Path to the host filesystem, typically "/rootfs". Used only for testing.
+	hostRootFsPath string
+
+	// Exec implementation
+	executor exec.Interface
+}
+
+// NewNsenter constructs a new instance of NSEnter
+func NewNsenter(hostRootFsPath string, executor exec.Interface) (*NSEnter, error) {
+	ne := &NSEnter{
+		hostRootFsPath: hostRootFsPath,
+		executor:       executor,
+	}
+	if err := ne.initPaths(); err != nil {
+		return nil, err
+	}
+	return ne, nil
+}
+
+func (ne *NSEnter) initPaths() error {
+	ne.paths = map[string]string{}
+	binaries := []string{
+		"mount",
+		"findmnt",
+		"umount",
+		"systemd-run",
+		"stat",
+		"touch",
+		"mkdir",
+		"sh",
+		"chmod",
+		"realpath",
+	}
+	// search for the required commands in other locations besides /usr/bin
+	for _, binary := range binaries {
+		// check for binary under the following directories
+		for _, path := range []string{"/", "/bin", "/usr/sbin", "/usr/bin"} {
+			binPath := filepath.Join(path, binary)
+			if _, err := os.Stat(filepath.Join(ne.hostRootFsPath, binPath)); err != nil {
+				continue
+			}
+			ne.paths[binary] = binPath
+			break
+		}
+		// systemd-run is optional, bailout if we don't find any of the other binaries
+		if ne.paths[binary] == "" && binary != "systemd-run" {
+			return fmt.Errorf("unable to find %v", binary)
+		}
+	}
+	return nil
+}
+
+// Exec executes nsenter commands in hostProcMountNsPath mount namespace
+func (ne *NSEnter) Exec(cmd string, args []string) exec.Cmd {
+	hostProcMountNsPath := filepath.Join(ne.hostRootFsPath, mountNsPath)
+	fullArgs := append([]string{fmt.Sprintf("--mount=%s", hostProcMountNsPath), "--"},
+		append([]string{ne.AbsHostPath(cmd)}, args...)...)
+	klog.V(5).Infof("Running nsenter command: %v %v", nsenterPath, fullArgs)
+	return ne.executor.Command(nsenterPath, fullArgs...)
+}
+
+// Command returns a command wrapped with nsenter
+func (ne *NSEnter) Command(cmd string, args ...string) exec.Cmd {
+	return ne.Exec(cmd, args)
+}
+
+// CommandContext returns a CommandContext wrapped with nsenter
+func (ne *NSEnter) CommandContext(ctx context.Context, cmd string, args ...string) exec.Cmd {
+	hostProcMountNsPath := filepath.Join(ne.hostRootFsPath, mountNsPath)
+	fullArgs := append([]string{fmt.Sprintf("--mount=%s", hostProcMountNsPath), "--"},
+		append([]string{ne.AbsHostPath(cmd)}, args...)...)
+	klog.V(5).Infof("Running nsenter command: %v %v", nsenterPath, fullArgs)
+	return ne.executor.CommandContext(ctx, nsenterPath, fullArgs...)
+}
+
+// LookPath returns a LookPath wrapped with nsenter
+func (ne *NSEnter) LookPath(file string) (string, error) {
+	return "", fmt.Errorf("not implemented, error looking up : %s", file)
+}
+
+// AbsHostPath returns the absolute runnable path for a specified command
+func (ne *NSEnter) AbsHostPath(command string) string {
+	path, ok := ne.paths[command]
+	if !ok {
+		return command
+	}
+	return path
+}
+
+// SupportsSystemd checks whether command systemd-run exists
+func (ne *NSEnter) SupportsSystemd() (string, bool) {
+	systemdRunPath, ok := ne.paths["systemd-run"]
+	return systemdRunPath, ok && systemdRunPath != ""
+}
+
+// EvalSymlinks returns the path name on the host after evaluating symlinks on the
+// host.
+// mustExist makes EvalSymlinks to return error when the path does not
+// exist. When it's false, it evaluates symlinks of the existing part and
+// blindly adds the non-existing part:
+// pathname: /mnt/volume/non/existing/directory
+//     /mnt/volume exists
+//                non/existing/directory does not exist
+// -> It resolves symlinks in /mnt/volume to say /mnt/foo and returns
+//    /mnt/foo/non/existing/directory.
+//
+// BEWARE! EvalSymlinks is not able to detect symlink looks with mustExist=false!
+// If /tmp/link is symlink to /tmp/link, EvalSymlinks(/tmp/link/foo) returns /tmp/link/foo.
+func (ne *NSEnter) EvalSymlinks(pathname string, mustExist bool) (string, error) {
+	var args []string
+	if mustExist {
+		// "realpath -e: all components of the path must exist"
+		args = []string{"-e", pathname}
+	} else {
+		// "realpath -m: no path components need exist or be a directory"
+		args = []string{"-m", pathname}
+	}
+	outBytes, err := ne.Exec("realpath", args).CombinedOutput()
+	if err != nil {
+		klog.Infof("failed to resolve symbolic links on %s: %v", pathname, err)
+		return "", err
+	}
+	return strings.TrimSpace(string(outBytes)), nil
+}
+
+// KubeletPath returns the path name that can be accessed by containerized
+// kubelet. It is recommended to resolve symlinks on the host by EvalSymlinks
+// before calling this function
+func (ne *NSEnter) KubeletPath(pathname string) string {
+	return filepath.Join(ne.hostRootFsPath, pathname)
+}
+
+// NewFakeNsenter returns a NSEnter that does not run "nsenter --mount=... --",
+// but runs everything in the same mount namespace as the unit test binary.
+// rootfsPath is supposed to be a symlink, e.g. /tmp/xyz/rootfs -> /.
+// This fake NSEnter is enough for most operations, e.g. to resolve symlinks,
+// but it's not enough to call /bin/mount - unit tests don't run as root.
+func NewFakeNsenter(rootfsPath string) (*NSEnter, error) {
+	executor := &fakeExec{
+		rootfsPath: rootfsPath,
+	}
+	// prepare /rootfs/bin, usr/bin and usr/sbin
+	bin := filepath.Join(rootfsPath, "bin")
+	if err := os.Symlink("/bin", bin); err != nil {
+		return nil, err
+	}
+
+	usr := filepath.Join(rootfsPath, "usr")
+	if err := os.Mkdir(usr, 0755); err != nil {
+		return nil, err
+	}
+	usrbin := filepath.Join(usr, "bin")
+	if err := os.Symlink("/usr/bin", usrbin); err != nil {
+		return nil, err
+	}
+	usrsbin := filepath.Join(usr, "sbin")
+	if err := os.Symlink("/usr/sbin", usrsbin); err != nil {
+		return nil, err
+	}
+
+	return NewNsenter(rootfsPath, executor)
+}
+
+type fakeExec struct {
+	rootfsPath string
+}
+
+func (f fakeExec) Command(cmd string, args ...string) exec.Cmd {
+	// This will intentionaly panic if NSEnter does not provide enough arguments.
+	realCmd := args[2]
+	realArgs := args[3:]
+	return exec.New().Command(realCmd, realArgs...)
+}
+
+func (fakeExec) LookPath(file string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (fakeExec) CommandContext(ctx context.Context, cmd string, args ...string) exec.Cmd {
+	return nil
+}
+
+var _ exec.Interface = fakeExec{}
+var _ exec.Interface = &NSEnter{}

--- a/vendor/k8s.io/utils/nsenter/nsenter_unsupported.go
+++ b/vendor/k8s.io/utils/nsenter/nsenter_unsupported.go
@@ -1,0 +1,79 @@
+// +build !linux
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nsenter
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/utils/exec"
+)
+
+const (
+	// DefaultHostRootFsPath is path to host's filesystem mounted into container
+	// with kubelet.
+	DefaultHostRootFsPath = "/rootfs"
+)
+
+// Nsenter is a type alias for backward compatibility
+type Nsenter = NSEnter
+
+// NSEnter is part of experimental support for running the kubelet
+// in a container.
+type NSEnter struct {
+	// a map of commands to their paths on the host filesystem
+	Paths map[string]string
+}
+
+// NewNsenter constructs a new instance of NSEnter
+func NewNsenter(hostRootFsPath string, executor exec.Interface) (*Nsenter, error) {
+	return &Nsenter{}, nil
+}
+
+// Exec executes nsenter commands in hostProcMountNsPath mount namespace
+func (ne *NSEnter) Exec(cmd string, args []string) exec.Cmd {
+	return nil
+}
+
+// AbsHostPath returns the absolute runnable path for a specified command
+func (ne *NSEnter) AbsHostPath(command string) string {
+	return ""
+}
+
+// SupportsSystemd checks whether command systemd-run exists
+func (ne *NSEnter) SupportsSystemd() (string, bool) {
+	return "", false
+}
+
+// Command returns a command wrapped with nenter
+func (ne *NSEnter) Command(cmd string, args ...string) exec.Cmd {
+	return nil
+}
+
+// CommandContext returns a CommandContext wrapped with nsenter
+func (ne *NSEnter) CommandContext(ctx context.Context, cmd string, args ...string) exec.Cmd {
+	return nil
+}
+
+// LookPath returns a LookPath wrapped with nsenter
+func (ne *NSEnter) LookPath(file string) (string, error) {
+	return "", fmt.Errorf("not implemented, error looking up : %s", file)
+}
+
+var _ exec.Interface = &NSEnter{}

--- a/vendor/k8s.io/utils/path/file.go
+++ b/vendor/k8s.io/utils/path/file.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package path
+
+import (
+	"errors"
+	"os"
+)
+
+// LinkTreatment is the base type for constants used by Exists that indicate
+// how symlinks are treated for existence checks.
+type LinkTreatment int
+
+const (
+	// CheckFollowSymlink follows the symlink and verifies that the target of
+	// the symlink exists.
+	CheckFollowSymlink LinkTreatment = iota
+
+	// CheckSymlinkOnly does not follow the symlink and verfies only that they
+	// symlink itself exists.
+	CheckSymlinkOnly
+)
+
+// ErrInvalidLinkTreatment indicates that the link treatment behavior requested
+// is not a valid behavior.
+var ErrInvalidLinkTreatment = errors.New("unknown link behavior")
+
+// Exists checks if specified file, directory, or symlink exists. The behavior
+// of the test depends on the linkBehaviour argument. See LinkTreatment for
+// more details.
+func Exists(linkBehavior LinkTreatment, filename string) (bool, error) {
+	var err error
+
+	if linkBehavior == CheckFollowSymlink {
+		_, err = os.Stat(filename)
+	} else if linkBehavior == CheckSymlinkOnly {
+		_, err = os.Lstat(filename)
+	} else {
+		return false, ErrInvalidLinkTreatment
+	}
+
+	if os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// ReadDirNoStat returns a string of files/directories contained
+// in dirname without calling lstat on them.
+func ReadDirNoStat(dirname string) ([]string, error) {
+	if dirname == "" {
+		dirname = "."
+	}
+
+	f, err := os.Open(dirname)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	return f.Readdirnames(-1)
+}

--- a/vendor/k8s.io/utils/pointer/pointer.go
+++ b/vendor/k8s.io/utils/pointer/pointer.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pointer
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// AllPtrFieldsNil tests whether all pointer fields in a struct are nil.  This is useful when,
+// for example, an API struct is handled by plugins which need to distinguish
+// "no plugin accepted this spec" from "this spec is empty".
+//
+// This function is only valid for structs and pointers to structs.  Any other
+// type will cause a panic.  Passing a typed nil pointer will return true.
+func AllPtrFieldsNil(obj interface{}) bool {
+	v := reflect.ValueOf(obj)
+	if !v.IsValid() {
+		panic(fmt.Sprintf("reflect.ValueOf() produced a non-valid Value for %#v", obj))
+	}
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return true
+		}
+		v = v.Elem()
+	}
+	for i := 0; i < v.NumField(); i++ {
+		if v.Field(i).Kind() == reflect.Ptr && !v.Field(i).IsNil() {
+			return false
+		}
+	}
+	return true
+}
+
+// Int32Ptr returns a pointer to an int32
+func Int32Ptr(i int32) *int32 {
+	return &i
+}
+
+// Int64Ptr returns a pointer to an int64
+func Int64Ptr(i int64) *int64 {
+	return &i
+}
+
+// Int32PtrDerefOr dereference the int32 ptr and returns it i not nil,
+// else returns def.
+func Int32PtrDerefOr(ptr *int32, def int32) int32 {
+	if ptr != nil {
+		return *ptr
+	}
+	return def
+}
+
+// BoolPtr returns a pointer to a bool
+func BoolPtr(b bool) *bool {
+	return &b
+}
+
+// StringPtr returns a pointer to the passed string.
+func StringPtr(s string) *string {
+	return &s
+}
+
+// Float32Ptr returns a pointer to the passed float32.
+func Float32Ptr(i float32) *float32 {
+	return &i
+}
+
+// Float64Ptr returns a pointer to the passed float64.
+func Float64Ptr(i float64) *float64 {
+	return &i
+}

--- a/vendor/k8s.io/utils/semantic/deep_equal.go
+++ b/vendor/k8s.io/utils/semantic/deep_equal.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package semantic
+
+import (
+	"k8s.io/utils/third_party/forked/golang/reflect"
+)
+
+// Equalities is a map from type to a function comparing two values of
+// that type.
+type Equalities = reflect.Equalities
+
+// EqualitiesOrDie adds the given funcs and panics on any error.
+func EqualitiesOrDie(funcs ...interface{}) Equalities {
+	return reflect.EqualitiesOrDie(funcs...)
+}

--- a/vendor/k8s.io/utils/strings/escape.go
+++ b/vendor/k8s.io/utils/strings/escape.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strings
+
+import (
+	"strings"
+)
+
+// EscapeQualifiedName converts a plugin name, which might contain a / into a
+// string that is safe to use on-disk.  This assumes that the input has already
+// been validates as a qualified name.  we use "~" rather than ":" here in case
+// we ever use a filesystem that doesn't allow ":".
+func EscapeQualifiedName(in string) string {
+	return strings.Replace(in, "/", "~", -1)
+}
+
+// UnescapeQualifiedName converts an escaped plugin name (as per EscapeQualifiedName)
+// back to its normal form.  This assumes that the input has already been
+// validates as a qualified name.
+func UnescapeQualifiedName(in string) string {
+	return strings.Replace(in, "~", "/", -1)
+}

--- a/vendor/k8s.io/utils/strings/line_delimiter.go
+++ b/vendor/k8s.io/utils/strings/line_delimiter.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strings
+
+import (
+	"bytes"
+	"io"
+	"strings"
+)
+
+// LineDelimiter is a filter that will split input on lines
+// and bracket each line with the delimiter string.
+type LineDelimiter struct {
+	output    io.Writer
+	delimiter []byte
+	buf       bytes.Buffer
+}
+
+// NewLineDelimiter allocates a new io.Writer that will split input on lines
+// and bracket each line with the delimiter string.  This can be useful in
+// output tests where it is difficult to see and test trailing whitespace.
+func NewLineDelimiter(output io.Writer, delimiter string) *LineDelimiter {
+	return &LineDelimiter{output: output, delimiter: []byte(delimiter)}
+}
+
+// Write writes buf to the LineDelimiter ld. The only errors returned are ones
+// encountered while writing to the underlying output stream.
+func (ld *LineDelimiter) Write(buf []byte) (n int, err error) {
+	return ld.buf.Write(buf)
+}
+
+// Flush all lines up until now.  This will assume insert a linebreak at the current point of the stream.
+func (ld *LineDelimiter) Flush() (err error) {
+	lines := strings.Split(ld.buf.String(), "\n")
+	for _, line := range lines {
+		if _, err = ld.output.Write(ld.delimiter); err != nil {
+			return
+		}
+		if _, err = ld.output.Write([]byte(line)); err != nil {
+			return
+		}
+		if _, err = ld.output.Write(ld.delimiter); err != nil {
+			return
+		}
+		if _, err = ld.output.Write([]byte("\n")); err != nil {
+			return
+		}
+	}
+	return
+}

--- a/vendor/k8s.io/utils/strings/strings.go
+++ b/vendor/k8s.io/utils/strings/strings.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strings
+
+import (
+	"path"
+	"strings"
+)
+
+// SplitQualifiedName Splits a fully qualified name and returns its namespace and name.
+// Assumes that the input 'str' has been validated.
+func SplitQualifiedName(str string) (string, string) {
+	parts := strings.Split(str, "/")
+	if len(parts) < 2 {
+		return "", str
+	}
+	return parts[0], parts[1]
+}
+
+// JoinQualifiedName joins 'namespace' and 'name' and returns a fully qualified name
+// Assumes that the input is valid.
+func JoinQualifiedName(namespace, name string) string {
+	return path.Join(namespace, name)
+}
+
+// ShortenString returns the first N slice of a string.
+func ShortenString(str string, n int) string {
+	if len(str) <= n {
+		return str
+	}
+	return str[:n]
+}

--- a/vendor/k8s.io/utils/temp/dir.go
+++ b/vendor/k8s.io/utils/temp/dir.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package temp
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// Directory is an interface to a temporary directory, in which you can
+// create new files.
+type Directory interface {
+	// NewFile creates a new file in that directory. Calling NewFile
+	// with the same filename twice will result in an error.
+	NewFile(name string) (io.WriteCloser, error)
+	// Delete removes the directory and its content.
+	Delete() error
+}
+
+// Dir is wrapping an temporary directory on disk.
+type Dir struct {
+	// Name is the name (full path) of the created directory.
+	Name string
+}
+
+var _ Directory = &Dir{}
+
+// CreateTempDir returns a new Directory wrapping a temporary directory
+// on disk.
+func CreateTempDir(prefix string) (*Dir, error) {
+	name, err := ioutil.TempDir("", fmt.Sprintf("%s-", prefix))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Dir{
+		Name: name,
+	}, nil
+}
+
+// NewFile creates a new file in the specified directory.
+func (d *Dir) NewFile(name string) (io.WriteCloser, error) {
+	return os.OpenFile(
+		filepath.Join(d.Name, name),
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL,
+		0700,
+	)
+}
+
+// Delete the underlying directory, and all of its content.
+func (d *Dir) Delete() error {
+	return os.RemoveAll(d.Name)
+}

--- a/vendor/k8s.io/utils/temp/doc.go
+++ b/vendor/k8s.io/utils/temp/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package temp provides an interface to handle temporary files and
+// directories.
+package temp // import "k8s.io/utils/temp"

--- a/vendor/k8s.io/utils/temp/temptest/dir.go
+++ b/vendor/k8s.io/utils/temp/temptest/dir.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package temptest
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"k8s.io/utils/temp"
+)
+
+// FakeDir implements a Directory that is not backed on the
+// filesystem. This is useful for testing since the created "files" are
+// simple bytes.Buffer that can be inspected.
+type FakeDir struct {
+	Files   map[string]*FakeFile
+	Deleted bool
+}
+
+var _ temp.Directory = &FakeDir{}
+
+// NewFile returns a new FakeFile if the filename doesn't exist already.
+// This function will fail if the directory has already been deleted.
+func (d *FakeDir) NewFile(name string) (io.WriteCloser, error) {
+	if d.Deleted {
+		return nil, errors.New("can't create file in deleted FakeDir")
+	}
+	if d.Files == nil {
+		d.Files = map[string]*FakeFile{}
+	}
+	f := d.Files[name]
+	if f != nil {
+		return nil, fmt.Errorf(
+			"FakeDir already has file named %q",
+			name,
+		)
+	}
+	f = &FakeFile{}
+	d.Files[name] = f
+	return f, nil
+}
+
+// Delete doesn't remove anything, but records that the directory has
+// been deleted.
+func (d *FakeDir) Delete() error {
+	if d.Deleted {
+		return errors.New("failed to re-delete FakeDir")
+	}
+	d.Deleted = true
+	return nil
+}

--- a/vendor/k8s.io/utils/temp/temptest/doc.go
+++ b/vendor/k8s.io/utils/temp/temptest/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package temptest provides utilities for testing temp
+// files/directories testing.
+package temptest

--- a/vendor/k8s.io/utils/temp/temptest/file.go
+++ b/vendor/k8s.io/utils/temp/temptest/file.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package temptest
+
+import (
+	"bytes"
+	"errors"
+	"io"
+)
+
+// FakeFile is an implementation of a WriteCloser, that records what has
+// been written in the file (in a bytes.Buffer) and if the file has been
+// closed.
+type FakeFile struct {
+	Buffer bytes.Buffer
+	Closed bool
+}
+
+var _ io.WriteCloser = &FakeFile{}
+
+// Write appends the contents of p to the Buffer. If the file has
+// already been closed, an error is returned.
+func (f *FakeFile) Write(p []byte) (n int, err error) {
+	if f.Closed {
+		return 0, errors.New("can't write to closed FakeFile")
+	}
+	return f.Buffer.Write(p)
+}
+
+// Close records that the file has been closed. If the file has already
+// been closed, an error is returned.
+func (f *FakeFile) Close() error {
+	if f.Closed {
+		return errors.New("FakeFile was closed multiple times")
+	}
+	f.Closed = true
+	return nil
+}

--- a/vendor/k8s.io/utils/third_party/forked/golang/LICENSE
+++ b/vendor/k8s.io/utils/third_party/forked/golang/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/k8s.io/utils/third_party/forked/golang/PATENTS
+++ b/vendor/k8s.io/utils/third_party/forked/golang/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/k8s.io/utils/third_party/forked/golang/reflect/deep_equal.go
+++ b/vendor/k8s.io/utils/third_party/forked/golang/reflect/deep_equal.go
@@ -1,0 +1,398 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package reflect is a fork of go's standard library reflection package, which
+// allows for deep equal with equality functions defined.
+package reflect
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// Equalities is a map from type to a function comparing two values of
+// that type.
+type Equalities map[reflect.Type]reflect.Value
+
+// EqualitiesOrDie adds the given funcs and panics on any error.
+func EqualitiesOrDie(funcs ...interface{}) Equalities {
+	e := Equalities{}
+	if err := e.AddFuncs(funcs...); err != nil {
+		panic(err)
+	}
+	return e
+}
+
+// AddFuncs is a shortcut for multiple calls to AddFunc.
+func (e Equalities) AddFuncs(funcs ...interface{}) error {
+	for _, f := range funcs {
+		if err := e.AddFunc(f); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// AddFunc uses func as an equality function: it must take
+// two parameters of the same type, and return a boolean.
+func (e Equalities) AddFunc(eqFunc interface{}) error {
+	fv := reflect.ValueOf(eqFunc)
+	ft := fv.Type()
+	if ft.Kind() != reflect.Func {
+		return fmt.Errorf("expected func, got: %v", ft)
+	}
+	if ft.NumIn() != 2 {
+		return fmt.Errorf("expected two 'in' params, got: %v", ft)
+	}
+	if ft.NumOut() != 1 {
+		return fmt.Errorf("expected one 'out' param, got: %v", ft)
+	}
+	if ft.In(0) != ft.In(1) {
+		return fmt.Errorf("expected arg 1 and 2 to have same type, but got %v", ft)
+	}
+	var forReturnType bool
+	boolType := reflect.TypeOf(forReturnType)
+	if ft.Out(0) != boolType {
+		return fmt.Errorf("expected bool return, got: %v", ft)
+	}
+	e[ft.In(0)] = fv
+	return nil
+}
+
+// Below here is forked from go's reflect/deepequal.go
+
+// During deepValueEqual, must keep track of checks that are
+// in progress.  The comparison algorithm assumes that all
+// checks in progress are true when it reencounters them.
+// Visited comparisons are stored in a map indexed by visit.
+type visit struct {
+	a1  uintptr
+	a2  uintptr
+	typ reflect.Type
+}
+
+// unexportedTypePanic is thrown when you use this DeepEqual on something that has an
+// unexported type. It indicates a programmer error, so should not occur at runtime,
+// which is why it's not public and thus impossible to catch.
+type unexportedTypePanic []reflect.Type
+
+func (u unexportedTypePanic) Error() string { return u.String() }
+func (u unexportedTypePanic) String() string {
+	strs := make([]string, len(u))
+	for i, t := range u {
+		strs[i] = fmt.Sprintf("%v", t)
+	}
+	return "an unexported field was encountered, nested like this: " + strings.Join(strs, " -> ")
+}
+
+func makeUsefulPanic(v reflect.Value) {
+	if x := recover(); x != nil {
+		if u, ok := x.(unexportedTypePanic); ok {
+			u = append(unexportedTypePanic{v.Type()}, u...)
+			x = u
+		}
+		panic(x)
+	}
+}
+
+// deepValueEqual tests for deep equality using reflected types. The map argument tracks
+// comparisons that have already been seen, which allows short circuiting on
+// recursive types.
+func (e Equalities) deepValueEqual(v1, v2 reflect.Value, visited map[visit]bool, depth int) bool {
+	defer makeUsefulPanic(v1)
+
+	if !v1.IsValid() || !v2.IsValid() {
+		return v1.IsValid() == v2.IsValid()
+	}
+	if v1.Type() != v2.Type() {
+		return false
+	}
+	if fv, ok := e[v1.Type()]; ok {
+		return fv.Call([]reflect.Value{v1, v2})[0].Bool()
+	}
+	if v1.CanAddr() {
+		if fv, ok := e[v1.Addr().Type()]; ok {
+			return fv.Call([]reflect.Value{v1.Addr(), v2.Addr()})[0].Bool()
+		}
+	}
+
+	hard := func(k reflect.Kind) bool {
+		switch k {
+		case reflect.Array, reflect.Map, reflect.Slice, reflect.Struct:
+			return true
+		}
+		return false
+	}
+
+	if v1.CanAddr() && v2.CanAddr() && hard(v1.Kind()) {
+		addr1 := v1.UnsafeAddr()
+		addr2 := v2.UnsafeAddr()
+		if addr1 > addr2 {
+			// Canonicalize order to reduce number of entries in visited.
+			addr1, addr2 = addr2, addr1
+		}
+
+		// Short circuit if references are identical ...
+		if addr1 == addr2 {
+			return true
+		}
+
+		// ... or already seen
+		typ := v1.Type()
+		v := visit{addr1, addr2, typ}
+		if visited[v] {
+			return true
+		}
+
+		// Remember for later.
+		visited[v] = true
+	}
+
+	switch v1.Kind() {
+	case reflect.Array:
+		// We don't need to check length here because length is part of
+		// an array's type, which has already been filtered for.
+		for i := 0; i < v1.Len(); i++ {
+			if !e.deepValueEqual(v1.Index(i), v2.Index(i), visited, depth+1) {
+				return false
+			}
+		}
+		return true
+	case reflect.Slice:
+		if (v1.IsNil() || v1.Len() == 0) != (v2.IsNil() || v2.Len() == 0) {
+			return false
+		}
+		if v1.IsNil() || v1.Len() == 0 {
+			return true
+		}
+		if v1.Len() != v2.Len() {
+			return false
+		}
+		if v1.Pointer() == v2.Pointer() {
+			return true
+		}
+		for i := 0; i < v1.Len(); i++ {
+			if !e.deepValueEqual(v1.Index(i), v2.Index(i), visited, depth+1) {
+				return false
+			}
+		}
+		return true
+	case reflect.Interface:
+		if v1.IsNil() || v2.IsNil() {
+			return v1.IsNil() == v2.IsNil()
+		}
+		return e.deepValueEqual(v1.Elem(), v2.Elem(), visited, depth+1)
+	case reflect.Ptr:
+		return e.deepValueEqual(v1.Elem(), v2.Elem(), visited, depth+1)
+	case reflect.Struct:
+		for i, n := 0, v1.NumField(); i < n; i++ {
+			if !e.deepValueEqual(v1.Field(i), v2.Field(i), visited, depth+1) {
+				return false
+			}
+		}
+		return true
+	case reflect.Map:
+		if (v1.IsNil() || v1.Len() == 0) != (v2.IsNil() || v2.Len() == 0) {
+			return false
+		}
+		if v1.IsNil() || v1.Len() == 0 {
+			return true
+		}
+		if v1.Len() != v2.Len() {
+			return false
+		}
+		if v1.Pointer() == v2.Pointer() {
+			return true
+		}
+		for _, k := range v1.MapKeys() {
+			if !e.deepValueEqual(v1.MapIndex(k), v2.MapIndex(k), visited, depth+1) {
+				return false
+			}
+		}
+		return true
+	case reflect.Func:
+		if v1.IsNil() && v2.IsNil() {
+			return true
+		}
+		// Can't do better than this:
+		return false
+	default:
+		// Normal equality suffices
+		if !v1.CanInterface() || !v2.CanInterface() {
+			panic(unexportedTypePanic{})
+		}
+		return v1.Interface() == v2.Interface()
+	}
+}
+
+// DeepEqual is like reflect.DeepEqual, but focused on semantic equality
+// instead of memory equality.
+//
+// It will use e's equality functions if it finds types that match.
+//
+// An empty slice *is* equal to a nil slice for our purposes; same for maps.
+//
+// Unexported field members cannot be compared and will cause an imformative panic; you must add an Equality
+// function for these types.
+func (e Equalities) DeepEqual(a1, a2 interface{}) bool {
+	if a1 == nil || a2 == nil {
+		return a1 == a2
+	}
+	v1 := reflect.ValueOf(a1)
+	v2 := reflect.ValueOf(a2)
+	if v1.Type() != v2.Type() {
+		return false
+	}
+	return e.deepValueEqual(v1, v2, make(map[visit]bool), 0)
+}
+
+func (e Equalities) deepValueDerive(v1, v2 reflect.Value, visited map[visit]bool, depth int) bool {
+	defer makeUsefulPanic(v1)
+
+	if !v1.IsValid() || !v2.IsValid() {
+		return v1.IsValid() == v2.IsValid()
+	}
+	if v1.Type() != v2.Type() {
+		return false
+	}
+	if fv, ok := e[v1.Type()]; ok {
+		return fv.Call([]reflect.Value{v1, v2})[0].Bool()
+	}
+	if v1.CanAddr() {
+		if fv, ok := e[v1.Addr().Type()]; ok {
+			return fv.Call([]reflect.Value{v1.Addr(), v2.Addr()})[0].Bool()
+		}
+	}
+
+	hard := func(k reflect.Kind) bool {
+		switch k {
+		case reflect.Array, reflect.Map, reflect.Slice, reflect.Struct:
+			return true
+		}
+		return false
+	}
+
+	if v1.CanAddr() && v2.CanAddr() && hard(v1.Kind()) {
+		addr1 := v1.UnsafeAddr()
+		addr2 := v2.UnsafeAddr()
+		if addr1 > addr2 {
+			// Canonicalize order to reduce number of entries in visited.
+			addr1, addr2 = addr2, addr1
+		}
+
+		// Short circuit if references are identical ...
+		if addr1 == addr2 {
+			return true
+		}
+
+		// ... or already seen
+		typ := v1.Type()
+		v := visit{addr1, addr2, typ}
+		if visited[v] {
+			return true
+		}
+
+		// Remember for later.
+		visited[v] = true
+	}
+
+	switch v1.Kind() {
+	case reflect.Array:
+		// We don't need to check length here because length is part of
+		// an array's type, which has already been filtered for.
+		for i := 0; i < v1.Len(); i++ {
+			if !e.deepValueDerive(v1.Index(i), v2.Index(i), visited, depth+1) {
+				return false
+			}
+		}
+		return true
+	case reflect.Slice:
+		if v1.IsNil() || v1.Len() == 0 {
+			return true
+		}
+		if v1.Len() > v2.Len() {
+			return false
+		}
+		if v1.Pointer() == v2.Pointer() {
+			return true
+		}
+		for i := 0; i < v1.Len(); i++ {
+			if !e.deepValueDerive(v1.Index(i), v2.Index(i), visited, depth+1) {
+				return false
+			}
+		}
+		return true
+	case reflect.String:
+		if v1.Len() == 0 {
+			return true
+		}
+		if v1.Len() > v2.Len() {
+			return false
+		}
+		return v1.String() == v2.String()
+	case reflect.Interface:
+		if v1.IsNil() {
+			return true
+		}
+		return e.deepValueDerive(v1.Elem(), v2.Elem(), visited, depth+1)
+	case reflect.Ptr:
+		if v1.IsNil() {
+			return true
+		}
+		return e.deepValueDerive(v1.Elem(), v2.Elem(), visited, depth+1)
+	case reflect.Struct:
+		for i, n := 0, v1.NumField(); i < n; i++ {
+			if !e.deepValueDerive(v1.Field(i), v2.Field(i), visited, depth+1) {
+				return false
+			}
+		}
+		return true
+	case reflect.Map:
+		if v1.IsNil() || v1.Len() == 0 {
+			return true
+		}
+		if v1.Len() > v2.Len() {
+			return false
+		}
+		if v1.Pointer() == v2.Pointer() {
+			return true
+		}
+		for _, k := range v1.MapKeys() {
+			if !e.deepValueDerive(v1.MapIndex(k), v2.MapIndex(k), visited, depth+1) {
+				return false
+			}
+		}
+		return true
+	case reflect.Func:
+		if v1.IsNil() && v2.IsNil() {
+			return true
+		}
+		// Can't do better than this:
+		return false
+	default:
+		// Normal equality suffices
+		if !v1.CanInterface() || !v2.CanInterface() {
+			panic(unexportedTypePanic{})
+		}
+		return v1.Interface() == v2.Interface()
+	}
+}
+
+// DeepDerivative is similar to DeepEqual except that unset fields in a1 are
+// ignored (not compared). This allows us to focus on the fields that matter to
+// the semantic comparison.
+//
+// The unset fields include a nil pointer and an empty string.
+func (e Equalities) DeepDerivative(a1, a2 interface{}) bool {
+	if a1 == nil {
+		return true
+	}
+	v1 := reflect.ValueOf(a1)
+	v2 := reflect.ValueOf(a2)
+	if v1.Type() != v2.Type() {
+		return false
+	}
+	return e.deepValueDerive(v1, v2, make(map[visit]bool), 0)
+}

--- a/vendor/k8s.io/utils/trace/trace.go
+++ b/vendor/k8s.io/utils/trace/trace.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trace
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"k8s.io/klog"
+)
+
+type traceStep struct {
+	stepTime time.Time
+	msg      string
+}
+
+// Trace keeps track of a set of "steps" and allows us to log a specific
+// step if it took longer than its share of the total allowed time
+type Trace struct {
+	name      string
+	startTime time.Time
+	steps     []traceStep
+}
+
+// New creates a Trace with the specified name
+func New(name string) *Trace {
+	return &Trace{name, time.Now(), nil}
+}
+
+// Step adds a new step with a specific message
+func (t *Trace) Step(msg string) {
+	if t.steps == nil {
+		// traces almost always have less than 6 steps, do this to avoid more than a single allocation
+		t.steps = make([]traceStep, 0, 6)
+	}
+	t.steps = append(t.steps, traceStep{time.Now(), msg})
+}
+
+// Log is used to dump all the steps in the Trace
+func (t *Trace) Log() {
+	// an explicit logging request should dump all the steps out at the higher level
+	t.logWithStepThreshold(0)
+}
+
+func (t *Trace) logWithStepThreshold(stepThreshold time.Duration) {
+	var buffer bytes.Buffer
+	tracenum := rand.Int31()
+	endTime := time.Now()
+
+	totalTime := endTime.Sub(t.startTime)
+	buffer.WriteString(fmt.Sprintf("Trace[%d]: %q (started: %v) (total time: %v):\n", tracenum, t.name, t.startTime, totalTime))
+	lastStepTime := t.startTime
+	for _, step := range t.steps {
+		stepDuration := step.stepTime.Sub(lastStepTime)
+		if stepThreshold == 0 || stepDuration > stepThreshold || klog.V(4) {
+			buffer.WriteString(fmt.Sprintf("Trace[%d]: [%v] [%v] %v\n", tracenum, step.stepTime.Sub(t.startTime), stepDuration, step.msg))
+		}
+		lastStepTime = step.stepTime
+	}
+	stepDuration := endTime.Sub(lastStepTime)
+	if stepThreshold == 0 || stepDuration > stepThreshold || klog.V(4) {
+		buffer.WriteString(fmt.Sprintf("Trace[%d]: [%v] [%v] END\n", tracenum, endTime.Sub(t.startTime), stepDuration))
+	}
+
+	klog.Info(buffer.String())
+}
+
+// LogIfLong is used to dump steps that took longer than its share
+func (t *Trace) LogIfLong(threshold time.Duration) {
+	if time.Since(t.startTime) >= threshold {
+		// if any step took more than it's share of the total allowed time, it deserves a higher log level
+		stepThreshold := threshold / time.Duration(len(t.steps)+1)
+		t.logWithStepThreshold(stepThreshold)
+	}
+}
+
+// TotalTime can be used to figure out how long it took since the Trace was created
+func (t *Trace) TotalTime() time.Duration {
+	return time.Since(t.startTime)
+}


### PR DESCRIPTION
Allows additional arguments to the autoscaler for debugging purposes. This is not exposed in the CRD and setting this on the operator deployment will be overwritten by the CVO unless an override is explicitly added.