### PR TITLE
Operator: move report logic to ApplyStatus function

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -23,13 +23,13 @@ const (
 	ReasonCheckAutoscaler   = "UnableToCheckAutoscalers"
 )
 
-// ApplyStatusInterface is used to enable unit testing and does not
+// applyStatusInterface is used to enable unit testing and does not
 // implement all methods of StatusReporter.
-type ApplyStatusInterface interface {
-	CheckMachineAPI() (bool, error)
-	Fail(string, string) error
-	Progressing() error
-	Available(string, string) error
+type applyStatusInterface interface {
+	checkMachineAPI() (bool, error)
+	fail(string, string) error
+	progressing() error
+	available(string, string) error
 }
 
 // StatusReporter reports the status of the operator to the OpenShift
@@ -114,9 +114,9 @@ func (r *StatusReporter) ApplyConditions(conds []configv1.ClusterOperatorStatusC
 	return err
 }
 
-// Available reports the operator as available, not progressing, and
+// available reports the operator as available, not progressing, and
 // not failing -- optionally setting a reason and message.
-func (r *StatusReporter) Available(reason, message string) error {
+func (r *StatusReporter) available(reason, message string) error {
 	conditions := []configv1.ClusterOperatorStatusCondition{
 		{
 			Type:    configv1.OperatorAvailable,
@@ -139,7 +139,7 @@ func (r *StatusReporter) Available(reason, message string) error {
 
 // Fail reports the operator as failing but available, and not
 // progressing -- optionally setting a reason and message.
-func (r *StatusReporter) Fail(reason, message string) error {
+func (r *StatusReporter) fail(reason, message string) error {
 	conditions := []configv1.ClusterOperatorStatusCondition{
 		{
 			Type:   configv1.OperatorAvailable,
@@ -166,9 +166,9 @@ type AvailableChecker interface {
 	AvailableAndUpdated() (bool, error)
 }
 
-// Progressing reports the operator as progressing but available, and not
+// progressing reports the operator as progressing but available, and not
 // failing -- optionally setting a reason and message.
-func (r *StatusReporter) Progressing() error {
+func (r *StatusReporter) progressing() error {
 	glog.Infof("Syncing to version %v", r.releaseVersion)
 	conditions := []configv1.ClusterOperatorStatusCondition{
 		{
@@ -190,29 +190,29 @@ func (r *StatusReporter) Progressing() error {
 	return r.ApplyConditions(conditions, false)
 }
 
-// ApplyStatusInterface required here for test coverage of critical code.
+// applyStatusInterface required here for test coverage of critical code.
 // In actual operation, we are passing in StatusReporter.
-func ApplyStatus(r ApplyStatusInterface, check AvailableChecker) (bool, error) {
-	ok, err := r.CheckMachineAPI()
+func applyStatus(r applyStatusInterface, check AvailableChecker) (bool, error) {
+	ok, err := r.checkMachineAPI()
 	if err != nil {
-		r.Fail(ReasonMissingDependency, fmt.Sprintf("error checking machine-api operator status %v", err))
+		r.fail(ReasonMissingDependency, fmt.Sprintf("error checking machine-api operator status %v", err))
 		return false, nil
 	}
 	if !ok {
-		r.Fail(ReasonMissingDependency, "machine-api operator not ready")
+		r.fail(ReasonMissingDependency, "machine-api operator not ready")
 		return false, nil
 	}
 	ok, err = check.AvailableAndUpdated()
 	if err != nil {
-		r.Fail(ReasonCheckAutoscaler, fmt.Sprintf("error checking autoscaler operator status: %v", err))
+		r.fail(ReasonCheckAutoscaler, fmt.Sprintf("error checking autoscaler operator status: %v", err))
 		return false, nil
 	}
 	if !ok {
-		r.Progressing()
+		r.progressing()
 		return false, nil
 	}
 
-	err = r.Available(ReasonEmpty, "")
+	err = r.available(ReasonEmpty, "")
 	if err != nil {
 		return false, nil
 	}
@@ -231,16 +231,16 @@ func (r *StatusReporter) Report(stopCh <-chan struct{}, check AvailableChecker) 
 	// accordingly.  Rather than return errors and stop polling, most
 	// errors here should just be reported in the status message.
 	pollFunc := func() (bool, error) {
-		return ApplyStatus(r, check)
+		return applyStatus(r, check)
 	}
 
 	return wait.PollImmediateUntil(interval, pollFunc, stopCh)
 }
 
-// CheckMachineAPI checks the status of the machine-api-operator as
+// checkMachineAPI checks the status of the machine-api-operator as
 // reported to the CVO.  It returns true if the operator is available
 // and not failing.
-func (r *StatusReporter) CheckMachineAPI() (bool, error) {
+func (r *StatusReporter) checkMachineAPI() (bool, error) {
 	mao, err := r.client.ConfigV1().ClusterOperators().
 		Get("machine-api", metav1.GetOptions{})
 

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -55,7 +55,7 @@ func TestCheckMachineAPI(t *testing.T) {
 			client:         fakeconfigclientset.NewSimpleClientset(co),
 			relatedObjects: []configv1.ObjectReference{},
 		}
-		res, err := r.CheckMachineAPI()
+		res, err := r.checkMachineAPI()
 		assert.Equal(t, tc.expectedBool, res, "case %v: return expected %v but didn't get it", i, tc.expectedBool)
 		assert.Equal(t, tc.expectedErr, err, "case %v: expected %v error but didn't get it, got: ", i, tc.expectedErr, err)
 	}
@@ -83,30 +83,29 @@ func (c *MockCheck) AvailableAndUpdated() (bool, error) {
 	return c.isAvailableAndUpdated, nil
 }
 
-func (r *MockStatusReporter) CheckMachineAPI() (bool, error) {
+func (r *MockStatusReporter) checkMachineAPI() (bool, error) {
 	if r.isCheckMachineAPIFail {
 		return false, errors.New("returning failure")
 	}
 	return r.isCheckMachineAPI, nil
 }
 
-func (r *MockStatusReporter) Available(reason, message string) error {
+func (r *MockStatusReporter) available(reason, message string) error {
 	r.availableCalled = true
 	r.availableReason = reason
 	r.availableMessage = message
 	if !r.isAvailable {
 		return errors.New("returning failure")
-	} else {
-		return nil
 	}
+	return nil
 }
 
-func (r *MockStatusReporter) Progressing() error {
+func (r *MockStatusReporter) progressing() error {
 	r.progressingCalled = true
 	return nil
 }
 
-func (r *MockStatusReporter) Fail(reason, message string) error {
+func (r *MockStatusReporter) fail(reason, message string) error {
 	r.failReason = reason
 	r.failMessage = message
 	return nil
@@ -223,7 +222,7 @@ func TestApplyStatus(t *testing.T) {
 		},
 	}
 	for i, tc := range tCases {
-		ok, _ := ApplyStatus(tc.r, tc.c)
+		ok, _ := applyStatus(tc.r, tc.c)
 		if tc.applyExpectErr {
 			assert.Equal(t, tc.failReason, tc.r.failReason, "case %v: incorrect error return", i)
 		}

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"errors"
 	configv1 "github.com/openshift/api/config/v1"
 	osconfigv1 "github.com/openshift/api/config/v1"
 	fakeconfigclientset "github.com/openshift/client-go/config/clientset/versioned/fake"
@@ -57,6 +58,182 @@ func TestCheckMachineAPI(t *testing.T) {
 		res, err := r.CheckMachineAPI()
 		assert.Equal(t, tc.expectedBool, res, "case %v: return expected %v but didn't get it", i, tc.expectedBool)
 		assert.Equal(t, tc.expectedErr, err, "case %v: expected %v error but didn't get it, got: ", i, tc.expectedErr, err)
+	}
+}
+
+type MockStatusReporter struct {
+	isCheckMachineAPI                 bool
+	isCheckMachineAPIFail             bool
+	progressingCalled                 bool
+	isAvailable                       bool
+	availableCalled                   bool
+	availableReason, availableMessage string
+	failReason, failMessage           string
+}
+
+type MockCheck struct {
+	isFail                bool
+	isAvailableAndUpdated bool
+}
+
+func (c *MockCheck) AvailableAndUpdated() (bool, error) {
+	if c.isFail {
+		return false, errors.New("returning isFail")
+	}
+	return c.isAvailableAndUpdated, nil
+}
+
+func (r *MockStatusReporter) CheckMachineAPI() (bool, error) {
+	if r.isCheckMachineAPIFail {
+		return false, errors.New("returning failure")
+	}
+	return r.isCheckMachineAPI, nil
+}
+
+func (r *MockStatusReporter) Available(reason, message string) error {
+	r.availableCalled = true
+	r.availableReason = reason
+	r.availableMessage = message
+	if !r.isAvailable {
+		return errors.New("returning failure")
+	} else {
+		return nil
+	}
+}
+
+func (r *MockStatusReporter) Progressing() error {
+	r.progressingCalled = true
+	return nil
+}
+
+func (r *MockStatusReporter) Fail(reason, message string) error {
+	r.failReason = reason
+	r.failMessage = message
+	return nil
+}
+
+func TestApplyStatus(t *testing.T) {
+	tCases := []struct {
+		applyOk                 bool
+		applyExpectErr          bool
+		expectAvailableCalled   bool
+		expectProgressingCalled bool
+		failReason              string
+		c                       *MockCheck
+		r                       *MockStatusReporter
+	}{
+		{
+			// Case 0:  Everything succeeds and available is called;
+			// should return true, nil.
+			applyOk:                 true,
+			applyExpectErr:          false,
+			expectAvailableCalled:   true,
+			expectProgressingCalled: false,
+			c: &MockCheck{
+				isFail:                false,
+				isAvailableAndUpdated: true,
+			},
+			r: &MockStatusReporter{
+				isCheckMachineAPI:     true,
+				isCheckMachineAPIFail: false,
+				isAvailable:           true,
+				availableCalled:       false,
+				progressingCalled:     false,
+			},
+		},
+		{
+			// Case 1:  check.AvailableAndUpdated() reports fail;
+			// should return false, nil.
+			applyOk:                 false,
+			applyExpectErr:          true,
+			expectAvailableCalled:   false,
+			expectProgressingCalled: false,
+			failReason:              ReasonCheckAutoscaler,
+			c: &MockCheck{
+				isFail:                true,
+				isAvailableAndUpdated: true,
+			},
+			r: &MockStatusReporter{
+				isCheckMachineAPI:     true,
+				isCheckMachineAPIFail: false,
+				isAvailable:           true,
+				availableCalled:       false,
+				progressingCalled:     false,
+			},
+		},
+		{
+			// Case 2:  check.AvailableAndUpdated() reports false;
+			// should call Progressing; return false, nil.
+			applyOk:                 false,
+			applyExpectErr:          false,
+			expectAvailableCalled:   false,
+			expectProgressingCalled: true,
+			failReason:              "",
+			c: &MockCheck{
+				isFail:                false,
+				isAvailableAndUpdated: false,
+			},
+			r: &MockStatusReporter{
+				isCheckMachineAPI:     true,
+				isCheckMachineAPIFail: false,
+				isAvailable:           true,
+				availableCalled:       false,
+				progressingCalled:     false,
+			},
+		},
+		{
+			// Case 3:  CheckMachineAPI() reports false;
+			// should fail with ReasonMissingDependency; return false, nil.
+			applyOk:                 false,
+			applyExpectErr:          false,
+			expectAvailableCalled:   false,
+			expectProgressingCalled: false,
+			failReason:              ReasonMissingDependency,
+			c: &MockCheck{
+				isFail:                false,
+				isAvailableAndUpdated: false,
+			},
+			r: &MockStatusReporter{
+				isCheckMachineAPI:     false,
+				isCheckMachineAPIFail: false,
+				isAvailable:           true,
+				availableCalled:       false,
+				progressingCalled:     false,
+			},
+		},
+		{
+			// Case 4:  CheckMachineAPI() reports error;
+			// should fail with ReasonMissingDependency; return false, nil.
+			applyOk:                 false,
+			applyExpectErr:          true,
+			expectAvailableCalled:   false,
+			expectProgressingCalled: false,
+			failReason:              ReasonMissingDependency,
+			c: &MockCheck{
+				isFail:                false,
+				isAvailableAndUpdated: false,
+			},
+			r: &MockStatusReporter{
+				isCheckMachineAPI:     false,
+				isCheckMachineAPIFail: true,
+				isAvailable:           true,
+				availableCalled:       false,
+				progressingCalled:     false,
+			},
+		},
+	}
+	for i, tc := range tCases {
+		ok, _ := ApplyStatus(tc.r, tc.c)
+		if tc.applyExpectErr {
+			assert.Equal(t, tc.failReason, tc.r.failReason, "case %v: incorrect error return", i)
+		}
+		assert.Equal(t, tc.applyOk, ok, "case %v: incorrect ok", i)
+		assert.Equal(t, tc.expectAvailableCalled, tc.r.availableCalled, "case %v: available called incorrect", i)
+		assert.Equal(t, tc.r.availableReason, "", "case %v: incorrect ok", i)
+		assert.Equal(t, tc.expectProgressingCalled, tc.r.progressingCalled, "case %v: incorrect progressingCalled", i)
+		if tc.r.isCheckMachineAPIFail {
+			assert.Equal(t, "error checking machine-api operator status returning failure", tc.r.failMessage, "case %v: incorrect failure message")
+		}
 	}
 }
 


### PR DESCRIPTION
This commit refactors business logic of Report() to
it's own function, ApplyStatus().  This assists
in unit testing.

This test also implements behavior validation for
critical status reporting logic.