### PR TITLE
Refactor CAS_controller available check and tests

### DIFF
--- a/pkg/controller/clusterautoscaler/clusterautoscaler_test.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_test.go
@@ -1,12 +1,19 @@
 package clusterautoscaler
 
 import (
+	"errors"
 	"fmt"
+	"github.com/openshift/cluster-autoscaler-operator/pkg/apis"
+	autoscalingv1alpha1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"strings"
 	"testing"
-
-	autoscalingv1alpha1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -123,5 +130,119 @@ func TestAutoscalerArgs(t *testing.T) {
 		if includesStringWithPrefix(args, e) {
 			t.Fatalf("found arg expected to be missing: %s", e)
 		}
+	}
+}
+
+type MockReconciler struct {
+	getAutoscalerOk bool
+	gASerrType      error
+	configVersion   string
+	isDCCResult     bool
+	calledIsDCC     bool
+}
+
+func (r *MockReconciler) GetAutoscaler(_ *autoscalingv1alpha1.ClusterAutoscaler) (*appsv1.Deployment, error) {
+	dep := &appsv1.Deployment{}
+
+	if !r.getAutoscalerOk {
+		return nil, r.gASerrType
+	}
+	dep.ObjectMeta.Annotations = make(map[string]string)
+	dep.ObjectMeta.Annotations["release.openshift.io/version"] = r.configVersion
+	return dep, nil
+}
+func (r *MockReconciler) isDeploymentControllerCurrent(dep *appsv1.Deployment) (bool, error) {
+	r.calledIsDCC = true
+	return r.isDCCResult, nil
+}
+
+// This test ensures we can actually get an autoscaler with fakeclient/client.
+// fakeclient.NewFakeClientWithScheme will os.Exit(1) with invalid scheme.
+func TestCanGetca(t *testing.T) {
+	tscheme := runtime.NewScheme()
+	apis.AddToScheme(tscheme)
+	_ = fakeclient.NewFakeClientWithScheme(tscheme, NewClusterAutoscaler())
+}
+
+func TestIsDeploymentUpdated(t *testing.T) {
+	deploymentError := errors.New("standard error")
+	s := schema.GroupResource{Group: "", Resource: "testing"}
+	notFoundError := kerrors.NewNotFound(s, "0")
+	tCases := []struct {
+		expectedError     error
+		expectedOk        bool
+		expectedCalledDCC bool
+		c                 *Config
+		r                 *MockReconciler
+	}{
+		// Case 0:  Everything should work, return true, nil
+		{
+			expectedError:     nil,
+			expectedOk:        true,
+			expectedCalledDCC: true,
+			c: &Config{
+				ReleaseVersion: "test-1",
+			},
+			r: &MockReconciler{
+				getAutoscalerOk: true,
+				configVersion:   "test-1",
+				isDCCResult:     true,
+				gASerrType:      nil,
+			},
+		},
+		// Case 1: Waiting on deployment; should return false, nil.
+		{
+			expectedError:     nil,
+			expectedOk:        false,
+			expectedCalledDCC: false,
+			c: &Config{
+				ReleaseVersion: "test-1",
+			},
+			r: &MockReconciler{
+				getAutoscalerOk: false,
+				configVersion:   "test-1",
+				isDCCResult:     true,
+				gASerrType:      notFoundError,
+			},
+		},
+		// Case 2: Error getting deployment; should return false, err.
+		{
+			expectedError:     deploymentError,
+			expectedOk:        false,
+			expectedCalledDCC: false,
+			c: &Config{
+				ReleaseVersion: "test-1",
+			},
+			r: &MockReconciler{
+				getAutoscalerOk: false,
+				configVersion:   "test-1",
+				isDCCResult:     true,
+				gASerrType:      deploymentError,
+			},
+		},
+		// Case 3: isDeploymentControllerCurrent returns false; should return false, nil.
+		{
+			expectedError:     nil,
+			expectedOk:        false,
+			expectedCalledDCC: true,
+			c: &Config{
+				ReleaseVersion: "test-1",
+			},
+			r: &MockReconciler{
+				getAutoscalerOk: true,
+				configVersion:   "test-1",
+				isDCCResult:     false,
+				gASerrType:      nil,
+			},
+		},
+	}
+
+	ca := NewClusterAutoscaler()
+	for i, tc := range tCases {
+		tc.r.calledIsDCC = false
+		ok, err := isDeploymentUpdated(tc.r, ca, tc.c)
+		assert.Equal(t, tc.expectedError, err, "case %v: incorrect error", i)
+		assert.Equal(t, tc.expectedOk, ok, "case %v: incorrect ok", i)
+		assert.Equal(t, tc.expectedCalledDCC, tc.r.calledIsDCC, "case %v: incorrect calledIsDCC", i)
 	}
 }


### PR DESCRIPTION
This commit refactors clusterautoscaler_controller.AvailableAndUpdated
in order to support better testing.

This commit also implements unit tests for critical section of
logic for determining if operand (clusterautoscaler) is ready
in order to properly report status=progressing/available.