### PR TITLE
pkg/util/FilterString: change function semantics

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -4,7 +4,7 @@ package util
 // returns a new slice with all instances of needle removed, and a
 // count of the number instances encountered.
 func FilterString(haystack []string, needle string) ([]string, int) {
-	newSlice := haystack[:0] // Share the backing array.
+	var newSlice []string
 	found := 0
 
 	for _, x := range haystack {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -37,7 +37,9 @@ var filterStringTests = []struct {
 
 func TestFilterString(t *testing.T) {
 	for _, tt := range filterStringTests {
+		tt := tt // capture range variable
 		t.Run(tt.label, func(t *testing.T) {
+			t.Parallel()
 			got, count := FilterString(tt.haystack, tt.needle)
 
 			if !reflect.DeepEqual(got, tt.output) {


### PR DESCRIPTION
The implementation of FilterString shares the same backing array and
capacity as the original parameter, so the storage is reused for the
filtered slice. However, the original contents are modified which may
be surprising for the caller.

This PR changes the existing semantics and the passed in slice is no
longer changed -- this may be a breaking change for the existing
callers.

I discovered this when running the following:

```console
$ go test -test.count 1000 | head -10
--- FAIL: TestFilterString (0.00s)
    --- FAIL: TestFilterString/single_instance (0.00s)
        util_test.go:44: got ["bar" "baz" "baz"], want ["bar" "baz"]
        util_test.go:48: got count 0, want count 1
    --- FAIL: TestFilterString/multiple_instances (0.00s)
        util_test.go:44: got ["bar" "bar"], want ["bar"]
        util_test.go:48: got count 1, want count 2
--- FAIL: TestFilterString (0.00s)
    --- FAIL: TestFilterString/single_instance (0.00s)
        util_test.go:44: got ["bar" "baz" "baz"], want ["bar" "baz"]
```

Additionally the unit test did not 'close over' the range variable. If
you log `tc.label` in the test you will sometimes see (as expected
given the existing scoping):

```console
--- PASS: TestFilterString (0.00s)
    --- PASS: TestFilterString/single_instance (0.00s)
        util_test.go:43: zero instances
    --- PASS: TestFilterString/multiple_instances (0.00s)
        util_test.go:43: zero instances
    --- PASS: TestFilterString/zero_instances (0.00s)
        util_test.go:43: zero instances
```

If you look closely you'll notice it is always running the `zero
instances` test case. This is to be expected because `t.Run()` uses a
go routine. Given the small number of test cases the for loop has run
to completion before any of the go routines have started. When they
do, the value of `tc` will be the last in the range.

To prevent this from happening I have:
- captured the range variable
- made the subtest run in parallel

With these changes I can run the following without issue:

```console
$ go test -test.count 1000 -parallel 100 -race
PASS
ok  	github.com/openshift/cluster-autoscaler-operator/pkg/util	2.064s

$ go test -test.count 1000 -parallel 100
PASS
ok  	github.com/openshift/cluster-autoscaler-operator/pkg/util	0.096s
```

Useful reading [1][2] and (new to me) scopelint [3].

[1] https://gist.github.com/posener/92a55c4cd441fc5e5e85f27bca008721
[2] https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
[3] https://github.com/kyoh86/scopelint