### PR TITLE
Make StatusReporter a Runnable added to the manager

### DIFF
--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -1,248 +1,40 @@
 package operator
 
 import (
-	"errors"
-	configv1 "github.com/openshift/api/config/v1"
-	osconfigv1 "github.com/openshift/api/config/v1"
-	fakeconfigclientset "github.com/openshift/client-go/config/clientset/versioned/fake"
-	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"fmt"
 	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	fakeconfigclient "github.com/openshift/client-go/config/clientset/versioned/fake"
+	"github.com/openshift/cluster-autoscaler-operator/pkg/apis"
+	autoscalingv1alpha1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1alpha1"
+	"github.com/openshift/cluster-autoscaler-operator/pkg/util"
+	cvorm "github.com/openshift/cluster-version-operator/lib/resourcemerge"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestCheckMachineAPI(t *testing.T) {
-	tConditions := []struct {
-		expectedErr  error
-		expectedBool bool
-		conditions   []osconfigv1.ClusterOperatorStatusCondition
-	}{
+func init() {
+	apis.AddToScheme(scheme.Scheme)
+}
+
+var ClusterOperatorGroupResource = schema.ParseGroupResource("clusteroperators.config.openshift.io")
+
+var ErrMachineAPINotFound = errors.NewNotFound(ClusterOperatorGroupResource, "machine-api")
+
+var (
+	// Available is the list of expected conditions for the operator
+	// when reporting as available and updated.
+	AvailableConditions = []configv1.ClusterOperatorStatusCondition{
 		{
-			expectedErr:  nil,
-			expectedBool: true,
-			conditions: []osconfigv1.ClusterOperatorStatusCondition{
-				{
-					Type:   configv1.OperatorAvailable,
-					Status: osconfigv1.ConditionTrue,
-				},
-				{
-					Type:   configv1.OperatorFailing,
-					Status: osconfigv1.ConditionFalse,
-				},
-			},
-		},
-		{
-			expectedErr:  nil,
-			expectedBool: false,
-			conditions: []osconfigv1.ClusterOperatorStatusCondition{
-				{
-					Type:   configv1.OperatorAvailable,
-					Status: osconfigv1.ConditionFalse,
-				},
-				{
-					Type:   configv1.OperatorFailing,
-					Status: osconfigv1.ConditionFalse,
-				},
-			},
-		},
-	}
-	co := &osconfigv1.ClusterOperator{
-		ObjectMeta: metav1.ObjectMeta{Name: "machine-api"},
-		Status:     osconfigv1.ClusterOperatorStatus{},
-	}
-	for i, tc := range tConditions {
-		co.Status.Conditions = tc.conditions
-		r := StatusReporter{
-			client:         fakeconfigclientset.NewSimpleClientset(co),
-			relatedObjects: []configv1.ObjectReference{},
-		}
-		res, err := r.checkMachineAPI()
-		assert.Equal(t, tc.expectedBool, res, "case %v: return expected %v but didn't get it", i, tc.expectedBool)
-		assert.Equal(t, tc.expectedErr, err, "case %v: expected %v error but didn't get it, got: ", i, tc.expectedErr, err)
-	}
-}
-
-type MockStatusReporter struct {
-	isCheckMachineAPI                 bool
-	isCheckMachineAPIFail             bool
-	progressingCalled                 bool
-	isAvailable                       bool
-	availableCalled                   bool
-	availableReason, availableMessage string
-	failReason, failMessage           string
-}
-
-type MockCheck struct {
-	isFail                bool
-	isAvailableAndUpdated bool
-}
-
-func (c *MockCheck) AvailableAndUpdated() (bool, error) {
-	if c.isFail {
-		return false, errors.New("returning isFail")
-	}
-	return c.isAvailableAndUpdated, nil
-}
-
-func (r *MockStatusReporter) checkMachineAPI() (bool, error) {
-	if r.isCheckMachineAPIFail {
-		return false, errors.New("returning failure")
-	}
-	return r.isCheckMachineAPI, nil
-}
-
-func (r *MockStatusReporter) available(reason, message string) error {
-	r.availableCalled = true
-	r.availableReason = reason
-	r.availableMessage = message
-	if !r.isAvailable {
-		return errors.New("returning failure")
-	}
-	return nil
-}
-
-func (r *MockStatusReporter) progressing() error {
-	r.progressingCalled = true
-	return nil
-}
-
-func (r *MockStatusReporter) fail(reason, message string) error {
-	r.failReason = reason
-	r.failMessage = message
-	return nil
-}
-
-func TestApplyStatus(t *testing.T) {
-	tCases := []struct {
-		applyOk                 bool
-		applyExpectErr          bool
-		expectAvailableCalled   bool
-		expectProgressingCalled bool
-		failReason              string
-		c                       *MockCheck
-		r                       *MockStatusReporter
-	}{
-		{
-			// Case 0:  Everything succeeds and available is called;
-			// should return true, nil.
-			applyOk:                 true,
-			applyExpectErr:          false,
-			expectAvailableCalled:   true,
-			expectProgressingCalled: false,
-			c: &MockCheck{
-				isFail:                false,
-				isAvailableAndUpdated: true,
-			},
-			r: &MockStatusReporter{
-				isCheckMachineAPI:     true,
-				isCheckMachineAPIFail: false,
-				isAvailable:           true,
-				availableCalled:       false,
-				progressingCalled:     false,
-			},
-		},
-		{
-			// Case 1:  check.AvailableAndUpdated() reports fail;
-			// should return false, nil.
-			applyOk:                 false,
-			applyExpectErr:          true,
-			expectAvailableCalled:   false,
-			expectProgressingCalled: false,
-			failReason:              ReasonCheckAutoscaler,
-			c: &MockCheck{
-				isFail:                true,
-				isAvailableAndUpdated: true,
-			},
-			r: &MockStatusReporter{
-				isCheckMachineAPI:     true,
-				isCheckMachineAPIFail: false,
-				isAvailable:           true,
-				availableCalled:       false,
-				progressingCalled:     false,
-			},
-		},
-		{
-			// Case 2:  check.AvailableAndUpdated() reports false;
-			// should call Progressing; return false, nil.
-			applyOk:                 false,
-			applyExpectErr:          false,
-			expectAvailableCalled:   false,
-			expectProgressingCalled: true,
-			failReason:              "",
-			c: &MockCheck{
-				isFail:                false,
-				isAvailableAndUpdated: false,
-			},
-			r: &MockStatusReporter{
-				isCheckMachineAPI:     true,
-				isCheckMachineAPIFail: false,
-				isAvailable:           true,
-				availableCalled:       false,
-				progressingCalled:     false,
-			},
-		},
-		{
-			// Case 3:  CheckMachineAPI() reports false;
-			// should fail with ReasonMissingDependency; return false, nil.
-			applyOk:                 false,
-			applyExpectErr:          false,
-			expectAvailableCalled:   false,
-			expectProgressingCalled: false,
-			failReason:              ReasonMissingDependency,
-			c: &MockCheck{
-				isFail:                false,
-				isAvailableAndUpdated: false,
-			},
-			r: &MockStatusReporter{
-				isCheckMachineAPI:     false,
-				isCheckMachineAPIFail: false,
-				isAvailable:           true,
-				availableCalled:       false,
-				progressingCalled:     false,
-			},
-		},
-		{
-			// Case 4:  CheckMachineAPI() reports error;
-			// should fail with ReasonMissingDependency; return false, nil.
-			applyOk:                 false,
-			applyExpectErr:          true,
-			expectAvailableCalled:   false,
-			expectProgressingCalled: false,
-			failReason:              ReasonMissingDependency,
-			c: &MockCheck{
-				isFail:                false,
-				isAvailableAndUpdated: false,
-			},
-			r: &MockStatusReporter{
-				isCheckMachineAPI:     false,
-				isCheckMachineAPIFail: true,
-				isAvailable:           true,
-				availableCalled:       false,
-				progressingCalled:     false,
-			},
-		},
-	}
-	for i, tc := range tCases {
-		ok, _ := applyStatus(tc.r, tc.c)
-		if tc.applyExpectErr {
-			assert.Equal(t, tc.failReason, tc.r.failReason, "case %v: incorrect error return", i)
-		}
-		assert.Equal(t, tc.applyOk, ok, "case %v: incorrect ok", i)
-		assert.Equal(t, tc.expectAvailableCalled, tc.r.availableCalled, "case %v: available called incorrect", i)
-		assert.Equal(t, tc.r.availableReason, "", "case %v: incorrect ok", i)
-		assert.Equal(t, tc.expectProgressingCalled, tc.r.progressingCalled, "case %v: incorrect progressingCalled", i)
-		if tc.r.isCheckMachineAPIFail {
-			assert.Equal(t, "error checking machine-api operator status returning failure", tc.r.failMessage, "case %v: incorrect failure message")
-		}
-	}
-}
-
-func TestApplyConditions(t *testing.T) {
-	conditions := []configv1.ClusterOperatorStatusCondition{
-		{
-			Type:    configv1.OperatorAvailable,
-			Status:  configv1.ConditionTrue,
-			Reason:  "testing",
-			Message: "testing",
+			Type:   configv1.OperatorAvailable,
+			Status: configv1.ConditionTrue,
 		},
 		{
 			Type:   configv1.OperatorProgressing,
@@ -253,21 +45,463 @@ func TestApplyConditions(t *testing.T) {
 			Status: configv1.ConditionFalse,
 		},
 	}
-	co := &osconfigv1.ClusterOperator{
-		ObjectMeta: metav1.ObjectMeta{Name: "cluster-autoscaler"},
-		Status:     osconfigv1.ClusterOperatorStatus{},
+
+	// FailingConditions is the list of expected conditions for the operator
+	// when reporting as failing.
+	FailingConditions = []configv1.ClusterOperatorStatusCondition{
+		{
+			Type:   configv1.OperatorAvailable,
+			Status: configv1.ConditionTrue,
+		},
+		{
+			Type:   configv1.OperatorProgressing,
+			Status: configv1.ConditionFalse,
+		},
+		{
+			Type:   configv1.OperatorFailing,
+			Status: configv1.ConditionTrue,
+		},
 	}
-	r := StatusReporter{
-		client:         fakeconfigclientset.NewSimpleClientset(co),
-		relatedObjects: []configv1.ObjectReference{},
-		releaseVersion: "testing-1",
+
+	// ProgressingConditions is the list of expected conditions for the operator
+	// when reporting as progressing.
+	ProgressingConditions = []configv1.ClusterOperatorStatusCondition{
+		{
+			Type:   configv1.OperatorAvailable,
+			Status: configv1.ConditionTrue,
+		},
+		{
+			Type:   configv1.OperatorProgressing,
+			Status: configv1.ConditionTrue,
+		},
+		{
+			Type:   configv1.OperatorFailing,
+			Status: configv1.ConditionFalse,
+		},
 	}
-	err := r.ApplyConditions(conditions, true)
-	assert.Equal(t, nil, err, "expected nil error")
-	co_check, err2 := r.GetOrCreateClusterOperator()
-	assert.Equal(t, nil, err2, "expected nil error2")
-	// Need to check a specific field as comparing all conditions time stamps
-	// will be off.
-	assert.Equal(t, configv1.ConditionTrue, co_check.Status.Conditions[0].Status, "expected same conditions")
-	assert.Equal(t, "testing-1", co_check.Status.Versions[0].Version, "expected same version")
+)
+
+const (
+	ClusterAutoscalerName      = "test"
+	ClusterAutoscalerNamespace = "test-namespace"
+	ReleaseVersion             = "v100.0.1"
+)
+
+var TestStatusReporterConfig = StatusReporterConfig{
+	ClusterAutoscalerName:      ClusterAutoscalerName,
+	ClusterAutoscalerNamespace: ClusterAutoscalerNamespace,
+	ReleaseVersion:             ReleaseVersion,
+	RelatedObjects:             []configv1.ObjectReference{},
+}
+
+// clusterAutoscaler is the default ClusterAutoscaler object used in test setup.
+var clusterAutoscaler = &autoscalingv1alpha1.ClusterAutoscaler{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "ClusterAutoscaler",
+		APIVersion: "autoscaling.openshift.io/v1alpha1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name: ClusterAutoscalerName,
+	},
+}
+
+// machineAPI is a ClusterOperator object representing the status of a mock
+// machine-api-operator.
+var machineAPI = NewTestClusterOperator(&configv1.ClusterOperator{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "ClusterOperator",
+		APIVersion: "config.openshift.io/v1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "machine-api",
+	},
+})
+
+// deployment represents the default ClusterAutoscaler deployment object.
+var deployment = NewTestDeployment(&appsv1.Deployment{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "Deployment",
+		APIVersion: "apps/v1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      fmt.Sprintf("cluster-autoscaler-%s", ClusterAutoscalerName),
+		Namespace: ClusterAutoscalerNamespace,
+		Annotations: map[string]string{
+			util.ReleaseVersionAnnotation: ReleaseVersion,
+		},
+	},
+	Status: appsv1.DeploymentStatus{
+		AvailableReplicas: 1,
+		UpdatedReplicas:   1,
+		Replicas:          1,
+	},
+})
+
+// TestDeployment wraps the appsv1.Deployment type to add helper methods.
+type TestDeployment struct {
+	appsv1.Deployment
+}
+
+// NewTestDeployment returns a new TestDeployment wrapping the given
+// appsv1.Deployment object.
+func NewTestDeployment(dep *appsv1.Deployment) *TestDeployment {
+	return &TestDeployment{Deployment: *dep}
+}
+
+// DeploymentCopy returns a deep copy of the wrapped appsv1.Deployment object.
+func (d *TestDeployment) DeploymentCopy() *appsv1.Deployment {
+	newDeployment := &appsv1.Deployment{}
+	d.Deployment.DeepCopyInto(newDeployment)
+
+	return newDeployment
+}
+
+// WithAvailableReplicas returns a copy of the wrapped appsv1.Deployment object
+// with the AvailableReplicas set to the given value.
+func (d *TestDeployment) WithAvailableReplicas(n int32) *appsv1.Deployment {
+	newDeployment := d.DeploymentCopy()
+	newDeployment.Status.AvailableReplicas = n
+
+	return newDeployment
+}
+
+// WithReleaseVersion returns a copy of the wrapped appsv1.Deployment object
+// with the release version annotation set to the given value.
+func (d *TestDeployment) WithReleaseVersion(v string) *appsv1.Deployment {
+	newDeployment := d.DeploymentCopy()
+	annotations := newDeployment.GetAnnotations()
+
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	annotations[util.ReleaseVersionAnnotation] = v
+	newDeployment.SetAnnotations(annotations)
+
+	return newDeployment
+}
+
+// TestClusterOperator wraps the ClusterOperator type to add helper methods.
+type TestClusterOperator struct {
+	configv1.ClusterOperator
+}
+
+// NewTestClusterOperator returns a new TestDeployment wrapping the given
+// OpenShift ClusterOperator object.
+func NewTestClusterOperator(co *configv1.ClusterOperator) *TestClusterOperator {
+	return &TestClusterOperator{ClusterOperator: *co}
+}
+
+// ClusterOperatorCopy returns a deep copy of the wrapped object.
+func (co *TestClusterOperator) ClusterOperatorCopy() *configv1.ClusterOperator {
+	newCO := &configv1.ClusterOperator{}
+	co.ClusterOperator.DeepCopyInto(newCO)
+
+	return newCO
+}
+
+// WithConditions returns a copy of the wrapped ClusterOperator object with the
+// status conditions set to the given list.
+func (co *TestClusterOperator) WithConditions(conds []configv1.ClusterOperatorStatusCondition) *configv1.ClusterOperator {
+	newCO := co.ClusterOperatorCopy()
+	newCO.Status.Conditions = conds
+
+	return newCO
+}
+
+func TestCheckMachineAPI(t *testing.T) {
+	testCases := []struct {
+		label        string
+		expectedBool bool
+		expectedErr  error
+		configObjs   []runtime.Object
+	}{
+		{
+			label:        "machine-api available",
+			expectedBool: true,
+			expectedErr:  nil,
+			configObjs: []runtime.Object{
+				machineAPI.WithConditions(AvailableConditions),
+			},
+		},
+		{
+			label:        "machine-api failing",
+			expectedBool: false,
+			expectedErr:  nil,
+			configObjs: []runtime.Object{
+				machineAPI.WithConditions(FailingConditions),
+			},
+		},
+		{
+			label:        "machine-api not found",
+			expectedBool: false,
+			expectedErr:  ErrMachineAPINotFound,
+			configObjs:   []runtime.Object{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.label, func(t *testing.T) {
+			reporter := &StatusReporter{
+				client:       fakeclient.NewFakeClient(),
+				configClient: fakeconfigclient.NewSimpleClientset(tc.configObjs...),
+				config:       &TestStatusReporterConfig,
+			}
+
+			ok, err := reporter.CheckMachineAPI()
+
+			if ok != tc.expectedBool {
+				t.Errorf("got %t, want %t", ok, tc.expectedBool)
+			}
+
+			if !equality.Semantic.DeepEqual(err, tc.expectedErr) {
+				t.Errorf("got %v, want %v", err, tc.expectedErr)
+			}
+		})
+	}
+}
+
+func TestCheckCheckClusterAutoscaler(t *testing.T) {
+	testCases := []struct {
+		label        string
+		expectedBool bool
+		expectedErr  error
+		objects      []runtime.Object
+	}{
+		{
+			label:        "no cluster-autoscaler",
+			expectedBool: true,
+			expectedErr:  nil,
+			objects:      []runtime.Object{},
+		},
+		{
+			label:        "no deployment",
+			expectedBool: false,
+			expectedErr:  nil,
+			objects: []runtime.Object{
+				clusterAutoscaler,
+			},
+		},
+		{
+			label:        "deployment wrong version",
+			expectedBool: false,
+			expectedErr:  nil,
+			objects: []runtime.Object{
+				clusterAutoscaler,
+				deployment.WithReleaseVersion("vBAD"),
+			},
+		},
+		{
+			label:        "deployment not available",
+			expectedBool: false,
+			expectedErr:  nil,
+			objects: []runtime.Object{
+				clusterAutoscaler,
+				deployment.WithAvailableReplicas(0),
+			},
+		},
+		{
+			label:        "available and updated",
+			expectedBool: true,
+			expectedErr:  nil,
+			objects: []runtime.Object{
+				clusterAutoscaler,
+				deployment.DeploymentCopy(),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.label, func(t *testing.T) {
+			reporter := &StatusReporter{
+				client:       fakeclient.NewFakeClient(tc.objects...),
+				configClient: fakeconfigclient.NewSimpleClientset(),
+				config:       &TestStatusReporterConfig,
+			}
+
+			ok, err := reporter.CheckClusterAutoscaler()
+
+			if ok != tc.expectedBool {
+				t.Errorf("got %t, want %t", ok, tc.expectedBool)
+			}
+
+			if !equality.Semantic.DeepEqual(err, tc.expectedErr) {
+				t.Errorf("got %v, want %v", err, tc.expectedErr)
+			}
+		})
+	}
+}
+
+func TestStatusChanges(t *testing.T) {
+	testCases := []struct {
+		label      string
+		expected   []configv1.ClusterOperatorStatusCondition
+		transition func(*StatusReporter) error
+	}{
+		{
+			label:    "available",
+			expected: AvailableConditions,
+			transition: func(r *StatusReporter) error {
+				return r.available("AvailableReason", "available message")
+			},
+		},
+		{
+			label:    "progressing",
+			expected: ProgressingConditions,
+			transition: func(r *StatusReporter) error {
+				return r.progressing("ProgressingReason", "progressing message")
+			},
+		},
+		{
+			label:    "failing",
+			expected: FailingConditions,
+			transition: func(r *StatusReporter) error {
+				return r.failing("FailingReason", "failing message")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.label, func(t *testing.T) {
+			reporter := &StatusReporter{
+				client:       fakeclient.NewFakeClient(),
+				configClient: fakeconfigclient.NewSimpleClientset(),
+				config:       &TestStatusReporterConfig,
+			}
+
+			err := tc.transition(reporter)
+			if err != nil {
+				t.Errorf("error applying status: %v", err)
+			}
+
+			co, err := reporter.GetClusterOperator()
+			if err != nil {
+				t.Errorf("error getting ClusterOperator: %v", err)
+			}
+
+			for _, cond := range tc.expected {
+				ok := cvorm.IsOperatorStatusConditionPresentAndEqual(
+					co.Status.Conditions, cond.Type, cond.Status,
+				)
+
+				if !ok {
+					t.Errorf("wrong status for condition: %s", cond.Type)
+				}
+			}
+		})
+	}
+}
+
+func TestReportStatus(t *testing.T) {
+	testCases := []struct {
+		label         string
+		expectedBool  bool
+		expectedErr   error
+		expectedConds []configv1.ClusterOperatorStatusCondition
+		clientObjs    []runtime.Object
+		configObjs    []runtime.Object
+	}{
+		{
+			label:         "machine-api not found",
+			expectedBool:  false,
+			expectedErr:   nil,
+			expectedConds: FailingConditions,
+			clientObjs:    []runtime.Object{},
+			configObjs:    []runtime.Object{},
+		},
+		{
+			label:         "machine-api not ready",
+			expectedBool:  false,
+			expectedErr:   nil,
+			expectedConds: FailingConditions,
+			clientObjs:    []runtime.Object{},
+			configObjs: []runtime.Object{
+				machineAPI.WithConditions(FailingConditions),
+			},
+		},
+		{
+			label:         "no cluster-autoscaler",
+			expectedBool:  true,
+			expectedErr:   nil,
+			expectedConds: AvailableConditions,
+			clientObjs:    []runtime.Object{},
+			configObjs: []runtime.Object{
+				machineAPI.WithConditions(AvailableConditions),
+			},
+		},
+		{
+			label:         "no cluster-autoscaler deployment",
+			expectedBool:  false,
+			expectedErr:   nil,
+			expectedConds: ProgressingConditions,
+			clientObjs: []runtime.Object{
+				clusterAutoscaler,
+			},
+			configObjs: []runtime.Object{
+				machineAPI.WithConditions(AvailableConditions),
+			},
+		},
+		{
+			label:         "deployment wrong version",
+			expectedBool:  false,
+			expectedErr:   nil,
+			expectedConds: ProgressingConditions,
+			clientObjs: []runtime.Object{
+				clusterAutoscaler,
+				deployment.WithReleaseVersion("vWRONG"),
+			},
+			configObjs: []runtime.Object{
+				machineAPI.WithConditions(AvailableConditions),
+			},
+		},
+		{
+			label:         "available and updated",
+			expectedBool:  true,
+			expectedErr:   nil,
+			expectedConds: AvailableConditions,
+			clientObjs: []runtime.Object{
+				clusterAutoscaler,
+				deployment.WithReleaseVersion(ReleaseVersion),
+			},
+			configObjs: []runtime.Object{
+				machineAPI.WithConditions(AvailableConditions),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.label, func(t *testing.T) {
+			reporter := &StatusReporter{
+				client:       fakeclient.NewFakeClient(tc.clientObjs...),
+				configClient: fakeconfigclient.NewSimpleClientset(tc.configObjs...),
+				config:       &TestStatusReporterConfig,
+			}
+
+			ok, err := reporter.ReportStatus()
+
+			if ok != tc.expectedBool {
+				t.Errorf("got %t, want %t", ok, tc.expectedBool)
+			}
+
+			if !equality.Semantic.DeepEqual(err, tc.expectedErr) {
+				t.Errorf("got %v, want %v", err, tc.expectedErr)
+			}
+
+			// Check that the ClusterOperator status is updated.
+			co, err := reporter.GetClusterOperator()
+			if err != nil {
+				t.Errorf("error getting ClusterOperator: %v", err)
+			}
+
+			for _, cond := range tc.expectedConds {
+				ok := cvorm.IsOperatorStatusConditionPresentAndEqual(
+					co.Status.Conditions, cond.Type, cond.Status,
+				)
+
+				if !ok {
+					t.Errorf("wrong status for condition: %s", cond.Type)
+				}
+			}
+		})
+	}
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,5 +1,16 @@
 package util
 
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Common Kubernetes object annotations.
+const (
+	ReleaseVersionAnnotation = "release.openshift.io/version"
+	CriticalPodAnnotation    = "scheduler.alpha.kubernetes.io/critical-pod"
+)
+
 // FilterString removes any instances of the needle from haystack.  It
 // returns a new slice with all instances of needle removed, and a
 // count of the number instances encountered.
@@ -16,4 +27,35 @@ func FilterString(haystack []string, needle string) ([]string, int) {
 	}
 
 	return newSlice, found
+}
+
+// ReleaseVersionMatches checks whether a Kubernetes object has an OpenShift
+// release version annotation that matches the given version.
+func ReleaseVersionMatches(obj metav1.Object, version string) bool {
+	annotations := obj.GetAnnotations()
+
+	value, found := annotations[ReleaseVersionAnnotation]
+	if !found || value != version {
+		return false
+	}
+
+	return true
+}
+
+// DeploymentUpdated checks whether a Kubernetes deployment object's replicas
+// are fully updated and available.
+func DeploymentUpdated(dep *appsv1.Deployment) bool {
+	if dep.Status.ObservedGeneration < dep.Generation {
+		return false
+	}
+
+	if dep.Status.UpdatedReplicas != dep.Status.Replicas {
+		return false
+	}
+
+	if dep.Status.AvailableReplicas == 0 {
+		return false
+	}
+
+	return true
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -3,39 +3,42 @@ package util
 import (
 	"reflect"
 	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var filterStringTests = []struct {
-	label    string
-	needle   string
-	haystack []string
-	output   []string
-	count    int
-}{
-	{
-		label:    "single instance",
-		needle:   "foo",
-		haystack: []string{"foo", "bar", "baz"},
-		output:   []string{"bar", "baz"},
-		count:    1,
-	},
-	{
-		label:    "multiple instances",
-		needle:   "foo",
-		haystack: []string{"foo", "bar", "foo"},
-		output:   []string{"bar"},
-		count:    2,
-	},
-	{
-		label:    "zero instances",
-		needle:   "buzz",
-		haystack: []string{"foo", "bar", "foo"},
-		output:   []string{"foo", "bar", "foo"},
-		count:    0,
-	},
-}
-
 func TestFilterString(t *testing.T) {
+	filterStringTests := []struct {
+		label    string
+		needle   string
+		haystack []string
+		output   []string
+		count    int
+	}{
+		{
+			label:    "single instance",
+			needle:   "foo",
+			haystack: []string{"foo", "bar", "baz"},
+			output:   []string{"bar", "baz"},
+			count:    1,
+		},
+		{
+			label:    "multiple instances",
+			needle:   "foo",
+			haystack: []string{"foo", "bar", "foo"},
+			output:   []string{"bar"},
+			count:    2,
+		},
+		{
+			label:    "zero instances",
+			needle:   "buzz",
+			haystack: []string{"foo", "bar", "foo"},
+			output:   []string{"foo", "bar", "foo"},
+			count:    0,
+		},
+	}
+
 	for _, tt := range filterStringTests {
 		tt := tt // capture range variable
 		t.Run(tt.label, func(t *testing.T) {
@@ -48,6 +51,129 @@ func TestFilterString(t *testing.T) {
 
 			if count != tt.count {
 				t.Errorf("got count %d, want count %d", count, tt.count)
+			}
+		})
+	}
+}
+
+func TestReleaseVersionMatches(t *testing.T) {
+	releaseVersion := "v100"
+
+	deployment := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test-namespace",
+		},
+	}
+
+	testCases := []struct {
+		label        string
+		expectedBool bool
+		annotations  map[string]string
+	}{
+		{
+			label:        "no annotation",
+			expectedBool: false,
+			annotations:  nil,
+		},
+		{
+			label:        "wrong version",
+			expectedBool: false,
+			annotations: map[string]string{
+				ReleaseVersionAnnotation: "BAD",
+			},
+		},
+		{
+			label:        "correct version",
+			expectedBool: true,
+			annotations: map[string]string{
+				ReleaseVersionAnnotation: releaseVersion,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.label, func(t *testing.T) {
+			deployment.SetAnnotations(tc.annotations)
+
+			ok := ReleaseVersionMatches(deployment, releaseVersion)
+			if ok != tc.expectedBool {
+				t.Errorf("got %t, want %t", ok, tc.expectedBool)
+			}
+		})
+	}
+}
+
+func TestDeploymentUpdated(t *testing.T) {
+	deployment := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test",
+			Namespace:  "test-namespace",
+			Generation: 100,
+		},
+	}
+
+	testCases := []struct {
+		label        string
+		expectedBool bool
+		status       appsv1.DeploymentStatus
+	}{
+		{
+			label:        "old generation",
+			expectedBool: false,
+			status: appsv1.DeploymentStatus{
+				AvailableReplicas:  10,
+				Replicas:           10,
+				UpdatedReplicas:    10,
+				ObservedGeneration: 10,
+			},
+		},
+		{
+			label:        "replicas not updated",
+			expectedBool: false,
+			status: appsv1.DeploymentStatus{
+				Replicas:           10,
+				UpdatedReplicas:    5,
+				ObservedGeneration: 100,
+			},
+		},
+		{
+			label:        "no available replicas",
+			expectedBool: false,
+			status: appsv1.DeploymentStatus{
+				AvailableReplicas:  0,
+				Replicas:           10,
+				UpdatedReplicas:    10,
+				ObservedGeneration: 100,
+			},
+		},
+		{
+			label:        "available and updated",
+			expectedBool: true,
+			status: appsv1.DeploymentStatus{
+				AvailableReplicas:  10,
+				Replicas:           10,
+				UpdatedReplicas:    10,
+				ObservedGeneration: 100,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.label, func(t *testing.T) {
+			deployment.Status = tc.status
+
+			ok := DeploymentUpdated(deployment)
+			if ok != tc.expectedBool {
+				t.Errorf("got %t, want %t", ok, tc.expectedBool)
 			}
 		})
 	}


### PR DESCRIPTION
This refactors the StatusReporter to satisfy the Runnable interface
and adds it to the manager when creating a new Operator instance.
This prevents it from starting before clients are set up, and from
reporting status before leader-election has succeeded.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1689146