### PR TITLE
Record ClusterAutoscaler events in correct namespace

### DIFF
--- a/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
@@ -269,7 +269,7 @@ func (r *Reconciler) AutoscalerName(ca *autoscalingv1alpha1.ClusterAutoscaler) t
 	}
 }
 
-// UpdateAnnotations updates the annoations on the given object to the values
+// UpdateAnnotations updates the annotations on the given object to the values
 // currently expected by the controller.
 func (r *Reconciler) UpdateAnnotations(obj metav1.Object) {
 	annotations := obj.GetAnnotations()

--- a/pkg/controller/clusterautoscaler/clusterautoscaler_test.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/cluster-autoscaler-operator/pkg/apis"
 	autoscalingv1alpha1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1alpha1"
 	"github.com/openshift/cluster-autoscaler-operator/pkg/util"
+	"github.com/openshift/cluster-autoscaler-operator/test/helpers"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -22,9 +23,10 @@ import (
 )
 
 const (
-	NvidiaGPU         = "nvidia.com/gpu"
-	TestNamespace     = "test-namespace"
-	TestCloudProvider = "testProvider"
+	NvidiaGPU          = "nvidia.com/gpu"
+	TestNamespace      = "test-namespace"
+	TestCloudProvider  = "testProvider"
+	TestReleaseVersion = "v100"
 )
 
 var (
@@ -42,10 +44,10 @@ var (
 )
 
 var TestReconcilerConfig = &Config{
-	ReleaseVersion: "v100",
 	Name:           "test",
 	Namespace:      TestNamespace,
 	CloudProvider:  TestCloudProvider,
+	ReleaseVersion: TestReleaseVersion,
 	Image:          "test/test:v100",
 	Replicas:       10,
 	Verbosity:      10,
@@ -296,6 +298,65 @@ func TestObjectReference(t *testing.T) {
 
 			if !equality.Semantic.DeepEqual(tc.reference, ref) {
 				t.Errorf("got %v, want %v", ref, tc.reference)
+			}
+		})
+	}
+}
+
+func TestUpdateAnnotations(t *testing.T) {
+	deployment := helpers.NewTestDeployment(&appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test-namespace",
+		},
+	})
+
+	expected := map[string]string{
+		util.CriticalPodAnnotation:    "",
+		util.ReleaseVersionAnnotation: TestReleaseVersion,
+	}
+
+	testCases := []struct {
+		label  string
+		object metav1.Object
+	}{
+		{
+			label:  "no prior annotations",
+			object: deployment.DeploymentCopy(),
+		},
+		{
+			label: "missing version annotation",
+			object: deployment.WithAnnotations(map[string]string{
+				util.CriticalPodAnnotation: "",
+			}),
+		},
+		{
+			label: "missing critical-pod annotation",
+			object: deployment.WithAnnotations(map[string]string{
+				util.ReleaseVersionAnnotation: TestReleaseVersion,
+			}),
+		},
+		{
+			label: "old version annotation",
+			object: deployment.WithAnnotations(map[string]string{
+				util.ReleaseVersionAnnotation: "vOLD",
+			}),
+		},
+	}
+
+	r := newFakeReconciler()
+
+	for _, tc := range testCases {
+		t.Run(tc.label, func(t *testing.T) {
+			r.UpdateAnnotations(tc.object)
+
+			got := tc.object.GetAnnotations()
+			if !equality.Semantic.DeepEqual(got, expected) {
+				t.Errorf("got %v, want %v", got, expected)
 			}
 		})
 	}

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/cluster-autoscaler-operator/pkg/apis"
 	autoscalingv1alpha1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1alpha1"
 	"github.com/openshift/cluster-autoscaler-operator/pkg/util"
+	"github.com/openshift/cluster-autoscaler-operator/test/helpers"
 	cvorm "github.com/openshift/cluster-version-operator/lib/resourcemerge"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -107,7 +108,7 @@ var clusterAutoscaler = &autoscalingv1alpha1.ClusterAutoscaler{
 
 // machineAPI is a ClusterOperator object representing the status of a mock
 // machine-api-operator.
-var machineAPI = NewTestClusterOperator(&configv1.ClusterOperator{
+var machineAPI = helpers.NewTestClusterOperator(&configv1.ClusterOperator{
 	TypeMeta: metav1.TypeMeta{
 		Kind:       "ClusterOperator",
 		APIVersion: "config.openshift.io/v1",
@@ -118,7 +119,7 @@ var machineAPI = NewTestClusterOperator(&configv1.ClusterOperator{
 })
 
 // deployment represents the default ClusterAutoscaler deployment object.
-var deployment = NewTestDeployment(&appsv1.Deployment{
+var deployment = helpers.NewTestDeployment(&appsv1.Deployment{
 	TypeMeta: metav1.TypeMeta{
 		Kind:       "Deployment",
 		APIVersion: "apps/v1",
@@ -136,78 +137,6 @@ var deployment = NewTestDeployment(&appsv1.Deployment{
 		Replicas:          1,
 	},
 })
-
-// TestDeployment wraps the appsv1.Deployment type to add helper methods.
-type TestDeployment struct {
-	appsv1.Deployment
-}
-
-// NewTestDeployment returns a new TestDeployment wrapping the given
-// appsv1.Deployment object.
-func NewTestDeployment(dep *appsv1.Deployment) *TestDeployment {
-	return &TestDeployment{Deployment: *dep}
-}
-
-// DeploymentCopy returns a deep copy of the wrapped appsv1.Deployment object.
-func (d *TestDeployment) DeploymentCopy() *appsv1.Deployment {
-	newDeployment := &appsv1.Deployment{}
-	d.Deployment.DeepCopyInto(newDeployment)
-
-	return newDeployment
-}
-
-// WithAvailableReplicas returns a copy of the wrapped appsv1.Deployment object
-// with the AvailableReplicas set to the given value.
-func (d *TestDeployment) WithAvailableReplicas(n int32) *appsv1.Deployment {
-	newDeployment := d.DeploymentCopy()
-	newDeployment.Status.AvailableReplicas = n
-
-	return newDeployment
-}
-
-// WithReleaseVersion returns a copy of the wrapped appsv1.Deployment object
-// with the release version annotation set to the given value.
-func (d *TestDeployment) WithReleaseVersion(v string) *appsv1.Deployment {
-	newDeployment := d.DeploymentCopy()
-	annotations := newDeployment.GetAnnotations()
-
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-
-	annotations[util.ReleaseVersionAnnotation] = v
-	newDeployment.SetAnnotations(annotations)
-
-	return newDeployment
-}
-
-// TestClusterOperator wraps the ClusterOperator type to add helper methods.
-type TestClusterOperator struct {
-	configv1.ClusterOperator
-}
-
-// NewTestClusterOperator returns a new TestDeployment wrapping the given
-// OpenShift ClusterOperator object.
-func NewTestClusterOperator(co *configv1.ClusterOperator) *TestClusterOperator {
-	return &TestClusterOperator{ClusterOperator: *co}
-}
-
-// ClusterOperatorCopy returns a deep copy of the wrapped object.
-func (co *TestClusterOperator) ClusterOperatorCopy() *configv1.ClusterOperator {
-	newCO := &configv1.ClusterOperator{}
-	co.ClusterOperator.DeepCopyInto(newCO)
-
-	return newCO
-}
-
-// WithConditions returns a copy of the wrapped ClusterOperator object with the
-// status conditions set to the given list.
-func (co *TestClusterOperator) WithConditions(conds []configv1.ClusterOperatorStatusCondition) *configv1.ClusterOperator {
-	newCO := co.ClusterOperatorCopy()
-	newCO.Status.Conditions = conds
-
-	return newCO
-}
 
 func TestCheckMachineAPI(t *testing.T) {
 	testCases := []struct {

--- a/test/helpers/helpers.go
+++ b/test/helpers/helpers.go
@@ -1,0 +1,88 @@
+package helpers
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-autoscaler-operator/pkg/util"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+// TestDeployment wraps the appsv1.Deployment type to add helper methods.
+type TestDeployment struct {
+	appsv1.Deployment
+}
+
+// NewTestDeployment returns a new TestDeployment wrapping the given
+// appsv1.Deployment object.
+func NewTestDeployment(dep *appsv1.Deployment) *TestDeployment {
+	return &TestDeployment{Deployment: *dep}
+}
+
+// DeploymentCopy returns a deep copy of the wrapped appsv1.Deployment object.
+func (d *TestDeployment) DeploymentCopy() *appsv1.Deployment {
+	newDeployment := &appsv1.Deployment{}
+	d.Deployment.DeepCopyInto(newDeployment)
+
+	return newDeployment
+}
+
+// WithAvailableReplicas returns a copy of the wrapped appsv1.Deployment object
+// with the AvailableReplicas set to the given value.
+func (d *TestDeployment) WithAvailableReplicas(n int32) *appsv1.Deployment {
+	newDeployment := d.DeploymentCopy()
+	newDeployment.Status.AvailableReplicas = n
+
+	return newDeployment
+}
+
+// WithReleaseVersion returns a copy of the wrapped appsv1.Deployment object
+// with the release version annotation set to the given value.
+func (d *TestDeployment) WithReleaseVersion(v string) *appsv1.Deployment {
+	newDeployment := d.DeploymentCopy()
+	annotations := newDeployment.GetAnnotations()
+
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	annotations[util.ReleaseVersionAnnotation] = v
+	newDeployment.SetAnnotations(annotations)
+
+	return newDeployment
+}
+
+// WithAnnotations returns a copy of the wrapped appsv1.Deployment object with
+// the annotations set to the given value.
+func (d *TestDeployment) WithAnnotations(a map[string]string) *appsv1.Deployment {
+	newDeployment := d.DeploymentCopy()
+	newDeployment.SetAnnotations(a)
+
+	return newDeployment
+}
+
+// TestClusterOperator wraps the ClusterOperator type to add helper methods.
+type TestClusterOperator struct {
+	configv1.ClusterOperator
+}
+
+// NewTestClusterOperator returns a new TestDeployment wrapping the given
+// OpenShift ClusterOperator object.
+func NewTestClusterOperator(co *configv1.ClusterOperator) *TestClusterOperator {
+	return &TestClusterOperator{ClusterOperator: *co}
+}
+
+// ClusterOperatorCopy returns a deep copy of the wrapped object.
+func (co *TestClusterOperator) ClusterOperatorCopy() *configv1.ClusterOperator {
+	newCO := &configv1.ClusterOperator{}
+	co.ClusterOperator.DeepCopyInto(newCO)
+
+	return newCO
+}
+
+// WithConditions returns a copy of the wrapped ClusterOperator object with the
+// status conditions set to the given list.
+func (co *TestClusterOperator) WithConditions(conds []configv1.ClusterOperatorStatusCondition) *configv1.ClusterOperator {
+	newCO := co.ClusterOperatorCopy()
+	newCO.Status.Conditions = conds
+
+	return newCO
+}


### PR DESCRIPTION
Because ClusterAutoscaler objects are cluster scoped, events related
to these objects were being recorded in the default namesapce.  This
causes the events to be recorded in the namespace that the deployment
is created in.

This also adds some unit tests for the `UpdateAnnotations` method.