### PR TITLE
Makefile: add -ginkgo.noColor=true for e2e invocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ test-e2e: ## Run e2e tests
 		-kubeconfig $${KUBECONFIG:-~/.kube/config} \
 		-machine-api-namespace $${NAMESPACE:-openshift-machine-api} \
 		-ginkgo.v \
+		-ginkgo.noColor=true \
 		-args -v 5 -logtostderr true
 
 .PHONY: lint


### PR DESCRIPTION
This is an attempt to remove the control characters from the CI logs.

If you look at the end of https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_machine-api-operator/277/pull-ci-openshift-machine-api-operator-master-e2e-aws-operator/778/build-log.txt you'll see lots of unprintable characters. The goal here is to remove these from CI logs to make them easier to consume and parse.

If you want colour you can always post process using ccze(1)[1]

[1] - https://github.com/cornet/ccze