### PR TITLE
Enable autoscaler --balance-similar-node-groups option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The operator manages the following custom resources:
       cluster-autoscaler
     Args:
       --logtostderr
+      --balance-similar-node-groups
       --cloud-provider=cluster-api
       --namespace=openshift-machine-api
       --expendable-pods-priority-cutoff=-10

--- a/examples/clusterautoscaler.yaml
+++ b/examples/clusterautoscaler.yaml
@@ -4,6 +4,7 @@ kind: "ClusterAutoscaler"
 metadata:
   name: "default"
 spec:
+  balanceSimilarNodeGroups: true
   podPriorityThreshold: -10
   resourceLimits:
     maxNodesTotal: 24

--- a/install/01_clusterautoscaler.crd.yaml
+++ b/install/01_clusterautoscaler.crd.yaml
@@ -31,6 +31,12 @@ spec:
         spec:
           description: Desired state of ClusterAutoscaler resource
           properties:
+            balanceSimilarNodeGroups:
+              description: BalanceSimilarNodeGroups enables/disables the `--balance-similar-node-groups`
+                cluster-autocaler feature. This feature will automatically identify
+                node groups with the same instance type and the same set of labels
+                and try to keep the respective sizes of those node groups balanced.
+              type: boolean
             maxPodGracePeriod:
               description: Gives pods graceful termination time before scaling down
               format: int32

--- a/pkg/apis/autoscaling/v1/clusterautoscaler_types.go
+++ b/pkg/apis/autoscaling/v1/clusterautoscaler_types.go
@@ -23,6 +23,13 @@ type ClusterAutoscalerSpec struct {
 	// Cluster Autoscaler actions, but only run when there are spare resources available,
 	// More info: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption
 	PodPriorityThreshold *int32 `json:"podPriorityThreshold,omitempty"`
+
+	// BalanceSimilarNodeGroups enables/disables the
+	// `--balance-similar-node-groups` cluster-autocaler feature.
+	// This feature will automatically identify node groups with
+	// the same instance type and the same set of labels and try
+	// to keep the respective sizes of those node groups balanced.
+	BalanceSimilarNodeGroups *bool `json:"balanceSimilarNodeGroups,omitempty"`
 }
 
 // ClusterAutoscalerStatus defines the observed state of ClusterAutoscaler

--- a/pkg/apis/autoscaling/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/autoscaling/v1/zz_generated.deepcopy.go
@@ -108,6 +108,11 @@ func (in *ClusterAutoscalerSpec) DeepCopyInto(out *ClusterAutoscalerSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.BalanceSimilarNodeGroups != nil {
+		in, out := &in.BalanceSimilarNodeGroups, &out.BalanceSimilarNodeGroups
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/autoscaling/v1/zz_generated.openapi.go
+++ b/pkg/apis/autoscaling/v1/zz_generated.openapi.go
@@ -45,12 +45,14 @@ func schema_pkg_apis_autoscaling_v1_ClusterAutoscaler(ref common.ReferenceCallba
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1.ClusterAutoscalerSpec"),
+							Description: "Desired state of ClusterAutoscaler resource",
+							Ref:         ref("github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1.ClusterAutoscalerSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1.ClusterAutoscalerStatus"),
+							Description: "Most recently observed status of ClusterAutoscaler resource",
+							Ref:         ref("github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1.ClusterAutoscalerStatus"),
 						},
 					},
 				},

--- a/pkg/controller/clusterautoscaler/clusterautoscaler.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler.go
@@ -48,6 +48,7 @@ const (
 	MemoryTotalArg                  AutoscalerArg = "--memory-total"
 	GPUTotalArg                     AutoscalerArg = "--gpu-total"
 	VerbosityArg                    AutoscalerArg = "--v"
+	BalanceSimilarNodeGroupsArg     AutoscalerArg = "--balance-similar-node-groups"
 )
 
 // AutoscalerArgs returns a slice of strings representing command line arguments
@@ -79,6 +80,10 @@ func AutoscalerArgs(ca *v1.ClusterAutoscaler, cfg *Config) []string {
 
 	if ca.Spec.ScaleDown != nil {
 		args = append(args, ScaleDownArgs(s.ScaleDown)...)
+	}
+
+	if ca.Spec.BalanceSimilarNodeGroups != nil && *ca.Spec.BalanceSimilarNodeGroups {
+		args = append(args, BalanceSimilarNodeGroupsArg.String())
 	}
 
 	return args


### PR DESCRIPTION
Add support for enabling the --balance-similar-node-groups
cluster-autoscaler option. It defaults to disabled but can be enabled
as follows:

```yaml
apiVersion: "autoscaling.openshift.io/v1"
kind: "ClusterAutoscaler"
metadata:
  name: "default"
spec:
  balanceSimilarNodeGroups: true
```