### PR TITLE
Monitoring integration

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -23,7 +23,10 @@ func main() {
 
 	printVersion()
 
-	config := operator.ConfigFromEnvironment()
+	config, err := operator.ConfigFromEnvironment()
+	if err != nil {
+		klog.Fatalf("Failed to get config from environment: %v", err)
+	}
 
 	operator, err := operator.New(config)
 	if err != nil {

--- a/install/00_namespace.yaml
+++ b/install/00_namespace.yaml
@@ -6,3 +6,5 @@ metadata:
   labels:
     name: openshift-machine-api
     openshift.io/run-level: "1"
+    # allow openshift-monitoring to look for ServiceMonitor objects in this namespace
+    openshift.io/cluster-monitoring: "true"

--- a/install/03_rbac.yaml
+++ b/install/03_rbac.yaml
@@ -221,3 +221,37 @@ subjects:
   - kind: ServiceAccount
     name: cluster-autoscaler
     namespace: openshift-machine-api
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s-cluster-autoscaler-operator
+  namespace: openshift-machine-api
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s-cluster-autoscaler-operator
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+
+---
+# Roles needed by prometheus to scrape Cluster Autoscaler Operator metrics endpoint
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s-cluster-autoscaler-operator
+  namespace: openshift-machine-api
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch

--- a/install/04_service.yaml
+++ b/install/04_service.yaml
@@ -15,6 +15,10 @@ spec:
     port: 443
     protocol: TCP
     targetPort: 8443
+  - name: metrics
+    port: 8080
+    targetPort: metrics
+    protocol: TCP
   selector:
     k8s-app: cluster-autoscaler-operator
   sessionAffinity: None

--- a/install/06_deployment.yaml
+++ b/install/06_deployment.yaml
@@ -46,8 +46,12 @@ spec:
           value: /etc/cluster-autoscaler-operator/tls
         - name: WEBHOOKS_PORT
           value: "8443"
+        - name: METRICS_PORT
+          value: "8080"
         ports:
         - containerPort: 8443
+        - name: metrics
+          containerPort: 8080
         resources:
           requests:
             cpu: 20m

--- a/install/09_servicemonitor.yaml
+++ b/install/09_servicemonitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: cluster-autoscaler-operator
+  name: cluster-autoscaler-operator
+  namespace: openshift-machine-api
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      port: metrics
+      scheme: http
+  namespaceSelector:
+    matchNames:
+      - openshift-machine-api
+  selector:
+    matchLabels:
+      k8s-app: cluster-autoscaler-operator

--- a/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	controllerName      = "cluster-autoscaler-controller"
+	controllerName      = "cluster_autoscaler_controller"
 	caServiceAccount    = "cluster-autoscaler"
 	caPriorityClassName = "system-cluster-critical"
 )

--- a/pkg/controller/machineautoscaler/machineautoscaler_controller.go
+++ b/pkg/controller/machineautoscaler/machineautoscaler_controller.go
@@ -36,7 +36,7 @@ const (
 	minSizeAnnotation = "machine.openshift.io/cluster-api-autoscaler-node-group-min-size"
 	maxSizeAnnotation = "machine.openshift.io/cluster-api-autoscaler-node-group-max-size"
 
-	controllerName = "machine-autoscaler-controller"
+	controllerName = "machine_autoscaler_controller"
 )
 
 var (

--- a/pkg/operator/config_test.go
+++ b/pkg/operator/config_test.go
@@ -1,6 +1,10 @@
 package operator
 
-import "testing"
+import (
+	"os"
+	"reflect"
+	"testing"
+)
 
 func TestNewConfig(t *testing.T) {
 	config := NewConfig()
@@ -10,5 +14,91 @@ func TestNewConfig(t *testing.T) {
 
 	if config.ClusterAutoscalerNamespace != DefaultClusterAutoscalerNamespace {
 		t.Fatal("missing default for ClusterAutoscalerNamespace")
+	}
+}
+
+func TestConfigFromEnvironment(t *testing.T) {
+	testCase := []struct {
+		envVars        map[string]string
+		expectedConfig *Config
+		expectedError  bool
+	}{
+		{
+			envVars: map[string]string{
+				"WEBHOOKS_PORT":                "1234",
+				"METRICS_PORT":                 "5678",
+				"LEADER_ELECTION":              "false",
+				"CLUSTER_AUTOSCALER_VERBOSITY": "5",
+				"WEBHOOKS_ENABLED":             "false",
+			},
+			expectedConfig: &Config{
+				WatchNamespace:                 DefaultWatchNamespace,
+				LeaderElection:                 false,
+				LeaderElectionNamespace:        DefaultLeaderElectionNamespace,
+				LeaderElectionID:               DefaultLeaderElectionID,
+				ClusterAutoscalerNamespace:     DefaultClusterAutoscalerNamespace,
+				ClusterAutoscalerName:          DefaultClusterAutoscalerName,
+				ClusterAutoscalerImage:         DefaultClusterAutoscalerImage,
+				ClusterAutoscalerReplicas:      DefaultClusterAutoscalerReplicas,
+				ClusterAutoscalerCloudProvider: DefaultClusterAutoscalerCloudProvider,
+				ClusterAutoscalerVerbosity:     5,
+				WebhooksEnabled:                false,
+				WebhooksPort:                   1234,
+				WebhooksCertDir:                DefaultWebhooksCertDir,
+				MetricsPort:                    5678,
+			},
+			expectedError: false,
+		},
+		{
+			envVars: map[string]string{
+				"METRICS_PORT": "bad_metrics_port",
+			},
+			expectedConfig: nil,
+			expectedError:  true,
+		},
+		{
+			envVars: map[string]string{
+				"WEBHOOKS_PORT": "bad_webhook_port",
+			},
+			expectedConfig: nil,
+			expectedError:  true,
+		},
+		{
+			envVars: map[string]string{
+				"LEADER_ELECTION": "bad_leader_election",
+			},
+			expectedConfig: nil,
+			expectedError:  true,
+		},
+		{
+			envVars: map[string]string{
+				"CLUSTER_AUTOSCALER_VERBOSITY": "bad_verbosity",
+			},
+			expectedConfig: nil,
+			expectedError:  true,
+		},
+		{
+			envVars: map[string]string{
+				"WEBHOOKS_ENABLED": "bad_webhooks_enabled",
+			},
+			expectedConfig: nil,
+			expectedError:  true,
+		},
+	}
+
+	for _, tc := range testCase {
+		for key, val := range tc.envVars {
+			os.Setenv(key, val)
+		}
+		got, err := ConfigFromEnvironment()
+		if (err != nil) != tc.expectedError {
+			t.Errorf("expected %v, got: %v", tc.expectedError, err)
+		}
+		if !reflect.DeepEqual(got, tc.expectedConfig) {
+			t.Errorf("expected: %v, got: %v", tc.expectedConfig, got)
+		}
+		for key := range tc.envVars {
+			os.Unsetenv(key)
+		}
 	}
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -51,6 +51,7 @@ func New(cfg *Config) (*Operator, error) {
 		LeaseDuration:           &leaderElectionLeaseDuration,
 		RenewDeadline:           &leaderElectionRenewDeadline,
 		RetryPeriod:             &leaderElectionRetryPeriod,
+		MetricsBindAddress:      fmt.Sprintf(":%d", cfg.MetricsPort),
 	}
 
 	operator.manager, err = manager.New(clientConfig, managerOptions)


### PR DESCRIPTION
This enables monitoring integration for cao.
- Controller runtime metrics are exposed for machine_autoscaler_controller and cluster_autoscaler_controller
- This enables any farther metric to be scraped by prometheus for either these controllers or any managed component i.e machine-provider/cluster-autoscaler