### PR TITLE
Add validator for ClusterAutoscaler resources

### DIFF
--- a/pkg/controller/clusterautoscaler/clusterautoscaler_test.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_test.go
@@ -44,7 +44,7 @@ var (
 	NvidiaGPUMax           int32 = 8
 )
 
-var TestReconcilerConfig = &Config{
+var TestReconcilerConfig = Config{
 	Name:           "test",
 	Namespace:      TestNamespace,
 	CloudProvider:  TestCloudProvider,
@@ -184,10 +184,11 @@ func TestCanGetca(t *testing.T) {
 func newFakeReconciler(initObjects ...runtime.Object) *Reconciler {
 	fakeClient := fakeclient.NewFakeClient(initObjects...)
 	return &Reconciler{
-		client:   fakeClient,
-		scheme:   scheme.Scheme,
-		recorder: record.NewFakeRecorder(128),
-		config:   TestReconcilerConfig,
+		client:    fakeClient,
+		scheme:    scheme.Scheme,
+		recorder:  record.NewFakeRecorder(128),
+		config:    TestReconcilerConfig,
+		validator: NewValidator(TestReconcilerConfig.Name),
 	}
 }
 
@@ -230,28 +231,28 @@ func TestReconcile(t *testing.T) {
 	tCases := []struct {
 		expectedError error
 		expectedRes   reconcile.Result
-		c             *Config
+		c             Config
 		d             *appsv1.Deployment
 	}{
 		// Case 0: should pass, returns {}, nil.
 		{
 			expectedError: nil,
 			expectedRes:   reconcile.Result{},
-			c:             &cfg1,
+			c:             cfg1,
 			d:             &dep1,
 		},
 		// Case 1: no ca found, should pass, returns {}, nil.
 		{
 			expectedError: nil,
 			expectedRes:   reconcile.Result{},
-			c:             &cfg2,
+			c:             cfg2,
 			d:             &dep1,
 		},
 		// Case 2: no dep found, should pass, returns {}, nil.
 		{
 			expectedError: nil,
 			expectedRes:   reconcile.Result{},
-			c:             &cfg1,
+			c:             cfg1,
 			d:             &appsv1.Deployment{},
 		},
 	}

--- a/pkg/controller/clusterautoscaler/validator.go
+++ b/pkg/controller/clusterautoscaler/validator.go
@@ -2,9 +2,13 @@ package clusterautoscaler
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
+	"time"
 
 	autoscalingv1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -15,6 +19,125 @@ import (
 type Validator struct {
 	client  client.Client
 	decoder *admission.Decoder
+
+	clusterAutoscalerName string
+}
+
+// NewValidator returns a new Validator configured with the given
+// ClusterAutoscaler singleton resource name.
+func NewValidator(name string) *Validator {
+	return &Validator{
+		clusterAutoscalerName: name,
+	}
+}
+
+// Validate validates the given ClusterAutoscaler resource and returns a bool
+// indicating whether validation passed, and possibly an aggregate error
+// representing any validation errors found.
+func (v *Validator) Validate(ca *autoscalingv1.ClusterAutoscaler) (bool, utilerrors.Aggregate) {
+	errs := []error{}
+
+	if ca == nil {
+		err := errors.New("ClusterAutoscaler is nil")
+		return false, utilerrors.NewAggregate([]error{err})
+	}
+
+	if ca.GetName() != v.clusterAutoscalerName {
+		errs = append(errs, fmt.Errorf("Name %q is invalid, only %q is allowed",
+			ca.GetName(), v.clusterAutoscalerName))
+	}
+
+	if limits := ca.Spec.ResourceLimits; limits != nil {
+		if aggErr := v.validateResourceLimits(limits); aggErr != nil {
+			errs = append(errs, aggErr.Errors()...)
+		}
+	}
+
+	if scaleDown := ca.Spec.ScaleDown; scaleDown != nil {
+		if aggErr := v.validateScaleDownConfig(scaleDown); aggErr != nil {
+			errs = append(errs, aggErr.Errors()...)
+		}
+	}
+
+	if len(errs) > 0 {
+		return false, utilerrors.NewAggregate(errs)
+	}
+
+	return true, nil
+}
+
+// validateResourceLimits validates ResourceLimits objects.
+func (v *Validator) validateResourceLimits(rl *autoscalingv1.ResourceLimits) utilerrors.Aggregate {
+	var errs []error
+
+	if rl.MaxNodesTotal != nil && *rl.MaxNodesTotal < 0 {
+		errs = append(errs,
+			errors.New("ResourceLimits.MaxNodesTotal must be greater than 0"))
+	}
+
+	if rl.Cores != nil {
+		if coresErrs := v.validateResourceRange(rl.Cores); coresErrs != nil {
+			errs = append(errs, fmt.Errorf("ResourceLimits.Cores: %v", coresErrs))
+		}
+	}
+
+	if rl.Memory != nil {
+		if memErrs := v.validateResourceRange(rl.Memory); memErrs != nil {
+			errs = append(errs, fmt.Errorf("ResourceLimits.Memory: %v", memErrs))
+		}
+	}
+
+	for _, gpu := range rl.GPUS {
+		// Construct a ResourceRange from the GPULimit so we can reuse the
+		// validation logic.  GPULimit is just a ResourceRange with a type.
+		rr := &autoscalingv1.ResourceRange{Min: gpu.Min, Max: gpu.Max}
+
+		if gpuErrs := v.validateResourceRange(rr); gpuErrs != nil {
+			errs = append(errs, fmt.Errorf("ResourceLimits.GPUS.%s: %v",
+				gpu.Type, gpuErrs))
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+// validateResourceRange validates ResourceRange objects.
+func (v *Validator) validateResourceRange(rr *autoscalingv1.ResourceRange) utilerrors.Aggregate {
+	var errs []error
+
+	if rr.Min < 0 || rr.Max < 0 {
+		errs = append(errs, errors.New("Min and Max must be greater than zero"))
+	}
+
+	if rr.Max < rr.Min {
+		errs = append(errs, errors.New("Max must be greater than or equal to Min"))
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+// validateScaleDownConfig validates ScaleDownConfig objects.
+func (v *Validator) validateScaleDownConfig(sd *autoscalingv1.ScaleDownConfig) utilerrors.Aggregate {
+	var errs []error
+
+	durations := map[string]*string{
+		"DelayAfterAdd":     sd.DelayAfterAdd,
+		"DelayAfterDelete":  sd.DelayAfterDelete,
+		"DelayAfterFailure": sd.DelayAfterFailure,
+		"UnneededTime":      sd.UnneededTime,
+	}
+
+	for name, durationString := range durations {
+		if durationString == nil {
+			continue
+		}
+
+		if _, err := time.ParseDuration(*durationString); err != nil {
+			errs = append(errs, fmt.Errorf("ScaleDown.%s: %v", name, err))
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
 }
 
 // Handle handles HTTP requests for admission webhook servers.
@@ -27,8 +150,11 @@ func (v *Validator) Handle(ctx context.Context, req admission.Request) admission
 
 	klog.Infof("Validation webhook called for ClustAutoscaler: %s", ca.GetName())
 
-	// TODO: Implement validations.
-	return admission.Allowed("ALLOW ALL")
+	if ok, err := v.Validate(ca); !ok {
+		return admission.Denied(err.Error())
+	}
+
+	return admission.Allowed("ClusterAutoscaler valid")
 }
 
 // InjectClient injects the client.

--- a/pkg/controller/clusterautoscaler/validator_test.go
+++ b/pkg/controller/clusterautoscaler/validator_test.go
@@ -1,0 +1,95 @@
+package clusterautoscaler
+
+import (
+	"testing"
+
+	autoscalingv1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1"
+	"k8s.io/utils/pointer"
+)
+
+func TestValidate(t *testing.T) {
+	validator := NewValidator("test")
+	ca := NewClusterAutoscaler()
+
+	testCases := []struct {
+		label      string
+		expectedOk bool
+		caFunc     func() *autoscalingv1.ClusterAutoscaler
+	}{
+		{
+			label:      "ClusterAutoscaler is valid",
+			expectedOk: true,
+			caFunc: func() *autoscalingv1.ClusterAutoscaler {
+				return ca.DeepCopy()
+			},
+		},
+		{
+			label:      "ClusterAutoscaler name is invalid",
+			expectedOk: false,
+			caFunc: func() *autoscalingv1.ClusterAutoscaler {
+				ca := ca.DeepCopy()
+				ca.SetName("invalid-name")
+				return ca
+			},
+		},
+		{
+			label:      "ClusterAutoscaler has negative MaxNodesTotal",
+			expectedOk: false,
+			caFunc: func() *autoscalingv1.ClusterAutoscaler {
+				ca := ca.DeepCopy()
+				ca.Spec.ResourceLimits.MaxNodesTotal = pointer.Int32Ptr(-10)
+				return ca
+			},
+		},
+		{
+			label:      "ClusterAutoscaler has negative Cores",
+			expectedOk: false,
+			caFunc: func() *autoscalingv1.ClusterAutoscaler {
+				ca := ca.DeepCopy()
+				ca.Spec.ResourceLimits.Cores.Min = -10
+				ca.Spec.ResourceLimits.Cores.Max = -10
+				return ca
+			},
+		},
+		{
+			label:      "ClusterAutoscaler has Max Cores lower than Min",
+			expectedOk: false,
+			caFunc: func() *autoscalingv1.ClusterAutoscaler {
+				ca := ca.DeepCopy()
+				ca.Spec.ResourceLimits.Cores.Min = 100
+				ca.Spec.ResourceLimits.Cores.Max = 10
+				return ca
+			},
+		},
+		{
+			label:      "ClusterAutoscaler has Max GPU lower than Min",
+			expectedOk: false,
+			caFunc: func() *autoscalingv1.ClusterAutoscaler {
+				ca := ca.DeepCopy()
+				ca.Spec.ResourceLimits.GPUS[0].Min = 100
+				ca.Spec.ResourceLimits.GPUS[0].Max = 10
+				return ca
+			},
+		},
+		{
+			label:      "ClusterAutoscaler has invalid ScaleDown durations",
+			expectedOk: false,
+			caFunc: func() *autoscalingv1.ClusterAutoscaler {
+				ca := ca.DeepCopy()
+				ca.Spec.ScaleDown.DelayAfterAdd = pointer.StringPtr("not-a-duration")
+				ca.Spec.ScaleDown.DelayAfterFailure = pointer.StringPtr("not-a-duration")
+				return ca
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.label, func(t *testing.T) {
+			ok, err := validator.Validate(tc.caFunc())
+
+			if ok != tc.expectedOk {
+				t.Errorf("got %v, want %v, err: %v", ok, tc.expectedOk, err)
+			}
+		})
+	}
+}

--- a/pkg/operator/webhookconfig.go
+++ b/pkg/operator/webhookconfig.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"io/ioutil"
 
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
@@ -50,7 +51,7 @@ func (w *WebhookConfigUpdater) Start(stopCh <-chan struct{}) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: WebhookConfigurationName,
 			Labels: map[string]string{
-				"k8s-app": OperatorName,
+				"k8s-app": fmt.Sprintf("%s-operator", OperatorName),
 			},
 		},
 	}
@@ -88,7 +89,7 @@ func (w *WebhookConfigUpdater) ValidatingWebhooks() ([]admissionregistrationv1be
 			Name: "clusterautoscalers.autoscaling.openshift.io",
 			ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
 				Service: &admissionregistrationv1beta1.ServiceReference{
-					Name:      OperatorName,
+					Name:      fmt.Sprintf("%s-operator", OperatorName),
 					Namespace: w.namespace,
 					Path:      pointer.StringPtr("/validate-clusterautoscalers"),
 				},


### PR DESCRIPTION
This adds a validator type for ClusterAutoscaler resources.  It handles validation both inside the reconciliation loop, where it returns early and records an event on failure, and for the validating webhook.

Here's an example of the reporting users now get earlier in the flow of deploying the cluster-autoscaler -- here the maximum number of cores was lower than the minimum and one of the durations in the scale down configuration was invalid:

```console
$ kubectl apply -f clusterautoscaler.yaml 
Error from server ([ResourceLimits.Cores: Max must be greater than or equal to Min, ScaleDown.DelayAfterAdd: time: invalid duration bad-duration]): error when creating "clusterautoscaler.yaml": admission webhook "clusterautoscalers.autoscaling.openshift.io" denied the request: [ResourceLimits.Cores: Max must be greater than or equal to Min, ScaleDown.DelayAfterAdd: time: invalid duration bad-duration]
```