### PR TITLE
Add validator for MachineAutoscaler resources

### DIFF
--- a/pkg/controller/clusterautoscaler/validator.go
+++ b/pkg/controller/clusterautoscaler/validator.go
@@ -35,7 +35,7 @@ func NewValidator(name string) *Validator {
 // indicating whether validation passed, and possibly an aggregate error
 // representing any validation errors found.
 func (v *Validator) Validate(ca *autoscalingv1.ClusterAutoscaler) (bool, utilerrors.Aggregate) {
-	errs := []error{}
+	var errs []error
 
 	if ca == nil {
 		err := errors.New("ClusterAutoscaler is nil")

--- a/pkg/controller/clusterautoscaler/validator_test.go
+++ b/pkg/controller/clusterautoscaler/validator_test.go
@@ -87,6 +87,10 @@ func TestValidate(t *testing.T) {
 		t.Run(tc.label, func(t *testing.T) {
 			ok, err := validator.Validate(tc.caFunc())
 
+			if !ok && err == nil {
+				t.Error("validation failed, but err is nil")
+			}
+
 			if ok != tc.expectedOk {
 				t.Errorf("got %v, want %v, err: %v", ok, tc.expectedOk, err)
 			}

--- a/pkg/controller/machineautoscaler/machineautoscaler_controller_test.go
+++ b/pkg/controller/machineautoscaler/machineautoscaler_controller_test.go
@@ -20,7 +20,7 @@ func init() {
 }
 
 // newFakeReconciler returns a new reconcile.Reconciler with a fake client.
-func newFakeReconciler(cfg *Config, initObjects ...runtime.Object) *Reconciler {
+func newFakeReconciler(cfg Config, initObjects ...runtime.Object) *Reconciler {
 	fakeClient := fakeclient.NewFakeClient(initObjects...)
 	return &Reconciler{
 		client:   fakeClient,
@@ -71,7 +71,7 @@ func TestRemoveSupportedGVK(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.label, func(t *testing.T) {
-			r := newFakeReconciler(&Config{
+			r := newFakeReconciler(Config{
 				Namespace:           TestNamespace,
 				SupportedTargetGVKs: tt.before,
 			})
@@ -123,7 +123,7 @@ func TestValidateReference(t *testing.T) {
 		},
 	}
 
-	r := newFakeReconciler(&Config{
+	r := newFakeReconciler(Config{
 		Namespace:           TestNamespace,
 		SupportedTargetGVKs: DefaultSupportedTargetGVKs(),
 	})

--- a/pkg/controller/machineautoscaler/validator.go
+++ b/pkg/controller/machineautoscaler/validator.go
@@ -1,0 +1,77 @@
+package machineautoscaler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	autoscalingv1beta1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1beta1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// Validator validates MachineAutoscaler resources.
+type Validator struct {
+	client  client.Client
+	decoder *admission.Decoder
+}
+
+// NewValidator returns a new Validator.
+func NewValidator() *Validator {
+	return &Validator{}
+}
+
+// Validate validates the given MachineAutoscaler resource.
+func (v *Validator) Validate(ma *autoscalingv1beta1.MachineAutoscaler) (bool, utilerrors.Aggregate) {
+	var errs []error
+
+	if ma == nil {
+		err := errors.New("MachineAutoscaler is nil")
+		return false, utilerrors.NewAggregate([]error{err})
+	}
+
+	if ma.Spec.MinReplicas < 0 || ma.Spec.MaxReplicas < 0 {
+		errs = append(errs, errors.New("min and max replicas must be greater than 0"))
+	}
+
+	if ma.Spec.MaxReplicas < ma.Spec.MinReplicas {
+		errs = append(errs, errors.New("max replicas must be greater than or equal to min"))
+	}
+
+	if len(errs) > 0 {
+		return false, utilerrors.NewAggregate(errs)
+	}
+
+	return true, nil
+}
+
+// Handle handles HTTP requests for admission webhook servers.
+func (v *Validator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	ma := &autoscalingv1beta1.MachineAutoscaler{}
+
+	if err := v.decoder.Decode(req, ma); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	klog.Infof("Validation webhook called for MachineAutoscaler: %s", ma.GetName())
+
+	if ok, err := v.Validate(ma); !ok {
+		return admission.Denied(err.Error())
+	}
+
+	return admission.Allowed("MachineAutoscaler valid")
+}
+
+// InjectClient injects the client.
+func (v *Validator) InjectClient(c client.Client) error {
+	v.client = c
+	return nil
+}
+
+// InjectDecoder injects the decoder.
+func (v *Validator) InjectDecoder(d *admission.Decoder) error {
+	v.decoder = d
+	return nil
+}

--- a/pkg/controller/machineautoscaler/validator_test.go
+++ b/pkg/controller/machineautoscaler/validator_test.go
@@ -1,0 +1,91 @@
+package machineautoscaler
+
+import (
+	"testing"
+
+	autoscalingv1beta1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewMachineAutoscaler() *autoscalingv1beta1.MachineAutoscaler {
+	return &autoscalingv1beta1.MachineAutoscaler{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MachineAutoscaler",
+			APIVersion: "autoscaling.openshift.io/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: autoscalingv1beta1.MachineAutoscalerSpec{
+			MinReplicas: 2,
+			MaxReplicas: 8,
+			ScaleTargetRef: autoscalingv1beta1.CrossVersionObjectReference{
+				APIVersion: "machine.openshift.io/v1beta1",
+				Kind:       "MachineSet",
+				Name:       "test",
+			},
+		},
+	}
+}
+
+func TestValidate(t *testing.T) {
+	validator := NewValidator()
+	ma := NewMachineAutoscaler()
+
+	testCases := []struct {
+		label      string
+		expectedOk bool
+		maFunc     func() *autoscalingv1beta1.MachineAutoscaler
+	}{
+		{
+			label:      "MachineAutoscaler is valid",
+			expectedOk: true,
+			maFunc: func() *autoscalingv1beta1.MachineAutoscaler {
+				return ma.DeepCopy()
+			},
+		},
+		{
+			label:      "MachineAutoscaler has negative MinReplicas",
+			expectedOk: false,
+			maFunc: func() *autoscalingv1beta1.MachineAutoscaler {
+				ma := ma.DeepCopy()
+				ma.Spec.MinReplicas = -10
+				return ma
+			},
+		},
+		{
+			label:      "MachineAutoscaler has negative MaxReplicas",
+			expectedOk: false,
+			maFunc: func() *autoscalingv1beta1.MachineAutoscaler {
+				ma := ma.DeepCopy()
+				ma.Spec.MaxReplicas = -10
+				return ma
+			},
+		},
+		{
+			label:      "MachineAutoscaler has MaxReplicas lower than MinReplicas",
+			expectedOk: false,
+			maFunc: func() *autoscalingv1beta1.MachineAutoscaler {
+				ma := ma.DeepCopy()
+				ma.Spec.MinReplicas = 8
+				ma.Spec.MaxReplicas = 2
+				return ma
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.label, func(t *testing.T) {
+			ok, err := validator.Validate(tc.maFunc())
+
+			if !ok && err == nil {
+				t.Error("validation failed, but err is nil")
+			}
+
+			if ok != tc.expectedOk {
+				t.Errorf("got %v, want %v, err: %v", ok, tc.expectedOk, err)
+			}
+		})
+	}
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -139,7 +139,7 @@ func (o *Operator) AddControllers() error {
 	}
 
 	// Setup MachineAutoscaler controller.
-	ma := machineautoscaler.NewReconciler(o.manager, &machineautoscaler.Config{
+	ma := machineautoscaler.NewReconciler(o.manager, machineautoscaler.Config{
 		Namespace:           o.config.ClusterAutoscalerNamespace,
 		SupportedTargetGVKs: machineautoscaler.DefaultSupportedTargetGVKs(),
 	})
@@ -180,6 +180,9 @@ func (o *Operator) AddWebhooks() error {
 
 	server.Register("/validate-clusterautoscalers",
 		&webhook.Admission{Handler: o.caReconciler.Validator()})
+
+	server.Register("/validate-machineautoscalers",
+		&webhook.Admission{Handler: o.maReconciler.Validator()})
 
 	return o.manager.Add(server)
 }

--- a/pkg/operator/webhookconfig.go
+++ b/pkg/operator/webhookconfig.go
@@ -110,6 +110,32 @@ func (w *WebhookConfigUpdater) ValidatingWebhooks() ([]admissionregistrationv1be
 				},
 			},
 		},
+		{
+			Name: "machineautoscalers.autoscaling.openshift.io",
+			ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+				Service: &admissionregistrationv1beta1.ServiceReference{
+					Name:      fmt.Sprintf("%s-operator", OperatorName),
+					Namespace: w.namespace,
+					Path:      pointer.StringPtr("/validate-machineautoscalers"),
+				},
+				CABundle: caBundle,
+			},
+			FailurePolicy: &failurePolicy,
+			SideEffects:   &sideEffects,
+			Rules: []admissionregistrationv1beta1.RuleWithOperations{
+				{
+					Rule: admissionregistrationv1beta1.Rule{
+						APIGroups:   []string{"autoscaling.openshift.io"},
+						APIVersions: []string{"v1beta1"},
+						Resources:   []string{"machineautoscalers"},
+					},
+					Operations: []admissionregistrationv1beta1.OperationType{
+						admissionregistrationv1beta1.Create,
+						admissionregistrationv1beta1.Update,
+					},
+				},
+			},
+		},
 	}
 
 	return webhooks, nil


### PR DESCRIPTION
This adds a validator type for MachineAutoscaler resources. It handles
validation both inside the reconciliation loop, where it returns early
and records an event on failure, and for the validating webhook.