### PR TITLE
Enable ignore-daemonsets-utilization and skp-nodes-with-local-storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ The operator manages the following custom resources:
       --scale-down-delay-after-add=10s
       --scale-down-delay-after-delete=10s
       --scale-down-delay-after-failure=10s
+      --ignore-daemonsets-utilization=false
+      --write-status-configmap=true
+      --skip-nodes-with-local-storage=true
   ```
 
 - __MachineAutoscaler__: This resource targets a node group and manages

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ The operator manages the following custom resources:
       --scale-down-delay-after-delete=10s
       --scale-down-delay-after-failure=10s
       --ignore-daemonsets-utilization=false
-      --write-status-configmap=true
       --skip-nodes-with-local-storage=true
   ```
 

--- a/examples/clusterautoscaler.yaml
+++ b/examples/clusterautoscaler.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   balanceSimilarNodeGroups: true
   ignoreDaemonsetsUtilization: false
-  writeStatusConfigMap: true
   skipNodesWithLocalStorage: true
   podPriorityThreshold: -10
   resourceLimits:

--- a/examples/clusterautoscaler.yaml
+++ b/examples/clusterautoscaler.yaml
@@ -5,6 +5,9 @@ metadata:
   name: "default"
 spec:
   balanceSimilarNodeGroups: true
+  ignoreDaemonsetsUtilization: false
+  writeStatusConfigMap: true
+  skipNodesWithLocalStorage: true
   podPriorityThreshold: -10
   resourceLimits:
     maxNodesTotal: 24

--- a/install/01_clusterautoscaler.crd.yaml
+++ b/install/01_clusterautoscaler.crd.yaml
@@ -32,10 +32,20 @@ spec:
           description: Desired state of ClusterAutoscaler resource
           properties:
             balanceSimilarNodeGroups:
-              description: BalanceSimilarNodeGroups enables/disables the `--balance-similar-node-groups`
+              description: 'BalanceSimilarNodeGroups enables/disables the `--balance-similar-node-groups`
                 cluster-autocaler feature. This feature will automatically identify
                 node groups with the same instance type and the same set of labels
-                and try to keep the respective sizes of those node groups balanced.
+                and try to keep the respective sizes of those node groups balanced.'
+              type: boolean
+            ignoreDaemonsetsUtilization:
+              description: 'Should CA ignore DaemonSet pods when calculating resource
+                utilization for scaling scaleDown'
+              type: boolean
+            writeStatusConfigMap:
+              description: 'Should CA write status information to a configmap'
+              type: boolean
+            skipNodesWithLocalStorage:
+              description: 'If true cluster autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath'
               type: boolean
             maxPodGracePeriod:
               description: Gives pods graceful termination time before scaling down

--- a/install/01_clusterautoscaler.crd.yaml
+++ b/install/01_clusterautoscaler.crd.yaml
@@ -41,9 +41,6 @@ spec:
               description: 'Should CA ignore DaemonSet pods when calculating resource
                 utilization for scaling scaleDown'
               type: boolean
-            writeStatusConfigMap:
-              description: 'Should CA write status information to a configmap'
-              type: boolean
             skipNodesWithLocalStorage:
               description: 'If true cluster autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath'
               type: boolean

--- a/pkg/apis/autoscaling/v1/clusterautoscaler_types.go
+++ b/pkg/apis/autoscaling/v1/clusterautoscaler_types.go
@@ -31,9 +31,6 @@ type ClusterAutoscalerSpec struct {
 	// to keep the respective sizes of those node groups balanced.
 	BalanceSimilarNodeGroups *bool `json:"balanceSimilarNodeGroups,omitempty"`
 
-	// Enables/Disables `--write-status-configmap` CA feature flag. Should CA write status information to a configmap. true by default
-	WriteStatusConfigMap *bool `json:"writeStatusConfigMap,omitempty"`
-
 	// Enables/Disables `--ignore-daemonsets-utilization` CA feature flag. Should CA ignore DaemonSet pods when calculating resource utilization for scaling down. false by default
 	IgnoreDaemonsetsUtilization *bool `json:"ignoreDaemonsetsUtilization,omitempty"`
 

--- a/pkg/apis/autoscaling/v1/clusterautoscaler_types.go
+++ b/pkg/apis/autoscaling/v1/clusterautoscaler_types.go
@@ -30,6 +30,15 @@ type ClusterAutoscalerSpec struct {
 	// the same instance type and the same set of labels and try
 	// to keep the respective sizes of those node groups balanced.
 	BalanceSimilarNodeGroups *bool `json:"balanceSimilarNodeGroups,omitempty"`
+
+	// Enables/Disables `--write-status-configmap` CA feature flag. Should CA write status information to a configmap. true by default
+	WriteStatusConfigMap *bool `json:"writeStatusConfigMap,omitempty"`
+
+	// Enables/Disables `--ignore-daemonsets-utilization` CA feature flag. Should CA ignore DaemonSet pods when calculating resource utilization for scaling down. false by default
+	IgnoreDaemonsetsUtilization *bool `json:"ignoreDaemonsetsUtilization,omitempty"`
+
+	// Enables/Disables `--skip-nodes-with-local-storage` CA feature flag. If true cluster autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath. true by default at autoscaler
+	SkipNodesWithLocalStorage *bool `json:"skipNodesWithLocalStorage,omitempty"`
 }
 
 // ClusterAutoscalerStatus defines the observed state of ClusterAutoscaler

--- a/pkg/apis/autoscaling/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/autoscaling/v1/zz_generated.deepcopy.go
@@ -113,11 +113,6 @@ func (in *ClusterAutoscalerSpec) DeepCopyInto(out *ClusterAutoscalerSpec) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.WriteStatusConfigMap != nil {
-		in, out := &in.WriteStatusConfigMap, &out.WriteStatusConfigMap
-		*out = new(bool)
-		**out = **in
-	}
 	if in.IgnoreDaemonsetsUtilization != nil {
 		in, out := &in.IgnoreDaemonsetsUtilization, &out.IgnoreDaemonsetsUtilization
 		*out = new(bool)

--- a/pkg/apis/autoscaling/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/autoscaling/v1/zz_generated.deepcopy.go
@@ -113,6 +113,21 @@ func (in *ClusterAutoscalerSpec) DeepCopyInto(out *ClusterAutoscalerSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.WriteStatusConfigMap != nil {
+		in, out := &in.WriteStatusConfigMap, &out.WriteStatusConfigMap
+		*out = new(bool)
+		**out = **in
+	}
+	if in.IgnoreDaemonsetsUtilization != nil {
+		in, out := &in.IgnoreDaemonsetsUtilization, &out.IgnoreDaemonsetsUtilization
+		*out = new(bool)
+		**out = **in
+	}
+	if in.SkipNodesWithLocalStorage != nil {
+		in, out := &in.SkipNodesWithLocalStorage, &out.SkipNodesWithLocalStorage
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/clusterautoscaler/clusterautoscaler.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler.go
@@ -49,7 +49,6 @@ const (
 	GPUTotalArg                     AutoscalerArg = "--gpu-total"
 	VerbosityArg                    AutoscalerArg = "--v"
 	BalanceSimilarNodeGroupsArg     AutoscalerArg = "--balance-similar-node-groups"
-	WriteStatusConfigMap            AutoscalerArg = "--write-status-configmap"
 	IgnoreDaemonsetsUtilization     AutoscalerArg = "--ignore-daemonsets-utilization"
 	SkipNodesWithLocalStorage       AutoscalerArg = "--skip-nodes-with-local-storage"
 )
@@ -87,10 +86,6 @@ func AutoscalerArgs(ca *v1.ClusterAutoscaler, cfg *Config) []string {
 
 	if ca.Spec.BalanceSimilarNodeGroups != nil && *ca.Spec.BalanceSimilarNodeGroups {
 		args = append(args, BalanceSimilarNodeGroupsArg.String())
-	}
-
-	if ca.Spec.WriteStatusConfigMap != nil && *ca.Spec.WriteStatusConfigMap {
-		args = append(args, WriteStatusConfigMap.String())
 	}
 
 	if ca.Spec.IgnoreDaemonsetsUtilization != nil && *ca.Spec.IgnoreDaemonsetsUtilization {

--- a/pkg/controller/clusterautoscaler/clusterautoscaler.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler.go
@@ -49,6 +49,9 @@ const (
 	GPUTotalArg                     AutoscalerArg = "--gpu-total"
 	VerbosityArg                    AutoscalerArg = "--v"
 	BalanceSimilarNodeGroupsArg     AutoscalerArg = "--balance-similar-node-groups"
+	WriteStatusConfigMap            AutoscalerArg = "--write-status-configmap"
+	IgnoreDaemonsetsUtilization     AutoscalerArg = "--ignore-daemonsets-utilization"
+	SkipNodesWithLocalStorage       AutoscalerArg = "--skip-nodes-with-local-storage"
 )
 
 // AutoscalerArgs returns a slice of strings representing command line arguments
@@ -84,6 +87,18 @@ func AutoscalerArgs(ca *v1.ClusterAutoscaler, cfg *Config) []string {
 
 	if ca.Spec.BalanceSimilarNodeGroups != nil && *ca.Spec.BalanceSimilarNodeGroups {
 		args = append(args, BalanceSimilarNodeGroupsArg.String())
+	}
+
+	if ca.Spec.WriteStatusConfigMap != nil && *ca.Spec.WriteStatusConfigMap {
+		args = append(args, WriteStatusConfigMap.String())
+	}
+
+	if ca.Spec.IgnoreDaemonsetsUtilization != nil && *ca.Spec.IgnoreDaemonsetsUtilization {
+		args = append(args, IgnoreDaemonsetsUtilization.String())
+	}
+
+	if ca.Spec.SkipNodesWithLocalStorage != nil && *ca.Spec.SkipNodesWithLocalStorage {
+		args = append(args, SkipNodesWithLocalStorage.String())
 	}
 
 	return args

--- a/pkg/controller/clusterautoscaler/clusterautoscaler_test.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_test.go
@@ -147,6 +147,9 @@ func TestAutoscalerArgs(t *testing.T) {
 		"--scale-down-delay-after-delete",
 		"--scale-down-delay-after-failure",
 		"--balance-similar-node-groups",
+		"--write-status-configmap",
+		"--ignore-daemonsets-utilization",
+		"--skip-nodes-with-local-storage",
 	}
 
 	for _, e := range expectedMissing {
@@ -156,17 +159,22 @@ func TestAutoscalerArgs(t *testing.T) {
 	}
 }
 
-// TestAutoscalerBalanceSimilarNodeGroupArgEnabled validates that the
-// --balance-similar-node-groups appears in the autoscaler args when
+// TestAutoscalerArgEnabled validates that args appear in the autoscaler args when
 // enabled in the ClusterAutoscalerSpec.
-func TestAutoscalerBalanceSimilarNodeGroupArgEnabled(t *testing.T) {
+func TestAutoscalerArgEnabled(t *testing.T) {
 	ca := NewClusterAutoscaler()
 	ca.Spec.BalanceSimilarNodeGroups = pointer.BoolPtr(true)
+	ca.Spec.WriteStatusConfigMap = pointer.BoolPtr(true)
+	ca.Spec.IgnoreDaemonsetsUtilization = pointer.BoolPtr(true)
+	ca.Spec.SkipNodesWithLocalStorage = pointer.BoolPtr(true)
 
 	args := AutoscalerArgs(ca, &Config{CloudProvider: TestCloudProvider, Namespace: TestNamespace})
 
 	expected := []string{
 		fmt.Sprintf("--balance-similar-node-groups"),
+		fmt.Sprintf("--write-status-configmap"),
+		fmt.Sprintf("--ignore-daemonsets-utilization"),
+		fmt.Sprintf("--skip-nodes-with-local-storage"),
 	}
 
 	for _, e := range expected {

--- a/pkg/controller/clusterautoscaler/clusterautoscaler_test.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_test.go
@@ -147,7 +147,6 @@ func TestAutoscalerArgs(t *testing.T) {
 		"--scale-down-delay-after-delete",
 		"--scale-down-delay-after-failure",
 		"--balance-similar-node-groups",
-		"--write-status-configmap",
 		"--ignore-daemonsets-utilization",
 		"--skip-nodes-with-local-storage",
 	}
@@ -164,7 +163,6 @@ func TestAutoscalerArgs(t *testing.T) {
 func TestAutoscalerArgEnabled(t *testing.T) {
 	ca := NewClusterAutoscaler()
 	ca.Spec.BalanceSimilarNodeGroups = pointer.BoolPtr(true)
-	ca.Spec.WriteStatusConfigMap = pointer.BoolPtr(true)
 	ca.Spec.IgnoreDaemonsetsUtilization = pointer.BoolPtr(true)
 	ca.Spec.SkipNodesWithLocalStorage = pointer.BoolPtr(true)
 
@@ -172,7 +170,6 @@ func TestAutoscalerArgEnabled(t *testing.T) {
 
 	expected := []string{
 		fmt.Sprintf("--balance-similar-node-groups"),
-		fmt.Sprintf("--write-status-configmap"),
 		fmt.Sprintf("--ignore-daemonsets-utilization"),
 		fmt.Sprintf("--skip-nodes-with-local-storage"),
 	}


### PR DESCRIPTION
These options are being used in 3.11. This PR enables these options and makes it possible to be able to set these at the cluster autoscaler operator.
https://jira.coreos.com/browse/CLOUD-603