### PR TITLE
Bug 1727015: Set Upgradeable condition on ClusterOperator status

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -114,6 +114,15 @@ func (r *StatusReporter) ApplyStatus(status configv1.ClusterOperatorStatus) erro
 		return err
 	}
 
+	// There currently is no circumstance that prevents the operator from
+	// upgrading, so we always set OperatorUpgradeable to true here.
+	upgradeable := configv1.ClusterOperatorStatusCondition{
+		Type:   configv1.OperatorUpgradeable,
+		Status: configv1.ConditionTrue,
+	}
+
+	cvorm.SetOperatorStatusCondition(&status.Conditions, upgradeable)
+
 	// Set the currently configured related objects.
 	status.RelatedObjects = r.config.RelatedObjects
 

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -55,6 +55,11 @@ var (
 			Status:             configv1.ConditionFalse,
 			LastTransitionTime: ConditionTransitionTime,
 		},
+		{
+			Type:               configv1.OperatorUpgradeable,
+			Status:             configv1.ConditionTrue,
+			LastTransitionTime: ConditionTransitionTime,
+		},
 	}
 
 	// DegradedConditions is the list of expected conditions for the operator
@@ -72,6 +77,11 @@ var (
 		},
 		{
 			Type:               configv1.OperatorDegraded,
+			Status:             configv1.ConditionTrue,
+			LastTransitionTime: ConditionTransitionTime,
+		},
+		{
+			Type:               configv1.OperatorUpgradeable,
 			Status:             configv1.ConditionTrue,
 			LastTransitionTime: ConditionTransitionTime,
 		},
@@ -93,6 +103,11 @@ var (
 		{
 			Type:               configv1.OperatorDegraded,
 			Status:             configv1.ConditionFalse,
+			LastTransitionTime: ConditionTransitionTime,
+		},
+		{
+			Type:               configv1.OperatorUpgradeable,
+			Status:             configv1.ConditionTrue,
 			LastTransitionTime: ConditionTransitionTime,
 		},
 	}


### PR DESCRIPTION
This sets the Upgradeable condition on the status of the operator's
ClusterOperator resource.  This always reports as true for now as
there is no condition which should prevent the operator from
upgrading.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1727015