### PR TITLE
Add manifest annotations for hosted deployment exclusions

### DIFF
--- a/install/04_service.yaml
+++ b/install/04_service.yaml
@@ -8,6 +8,7 @@ metadata:
     k8s-app: cluster-autoscaler-operator
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: cluster-autoscaler-operator-cert
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   type: ClusterIP
   ports:

--- a/install/06_servicemonitor.yaml
+++ b/install/06_servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
     k8s-app: cluster-autoscaler-operator
   name: cluster-autoscaler-operator
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/install/07_deployment.yaml
+++ b/install/07_deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: openshift-machine-api
   labels:
     k8s-app: cluster-autoscaler-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   replicas: 1
   selector:

--- a/install/08_clusteroperator.yaml
+++ b/install/08_clusteroperator.yaml
@@ -2,6 +2,8 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: cluster-autoscaler
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 status:
   versions:
   - name: operator


### PR DESCRIPTION
Enables the CVO to exclude manifests in an externally hosted control plane deployment
See https://github.com/openshift/cluster-version-operator/pull/252