### PR TITLE
add exclusion annotations to all resources

### DIFF
--- a/examples/clusterautoscaler.yaml
+++ b/examples/clusterautoscaler.yaml
@@ -3,6 +3,8 @@ apiVersion: "autoscaling.openshift.io/v1"
 kind: "ClusterAutoscaler"
 metadata:
   name: "default"
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   balanceSimilarNodeGroups: true
   ignoreDaemonsetsUtilization: false

--- a/examples/machineautoscaler.yaml
+++ b/examples/machineautoscaler.yaml
@@ -4,6 +4,8 @@ kind: "MachineAutoscaler"
 metadata:
   name: "worker-us-east-1a"
   namespace: "openshift-machine-api"
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   minReplicas: 1
   maxReplicas: 12

--- a/install/00_namespace.yaml
+++ b/install/00_namespace.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     name: openshift-machine-api
     openshift.io/run-level: "1"

--- a/install/01_clusterautoscaler.crd.yaml
+++ b/install/01_clusterautoscaler.crd.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"

--- a/install/02_machineautoscaler.crd.yaml
+++ b/install/02_machineautoscaler.crd.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: machineautoscalers.autoscaling.openshift.io
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   additionalPrinterColumns:
   - JSONPath: .spec.scaleTargetRef.kind

--- a/install/03_rbac.yaml
+++ b/install/03_rbac.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cluster-autoscaler-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups:
   - admissionregistration.k8s.io
@@ -40,6 +42,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: cluster-autoscaler-operator
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups:
   - autoscaling.openshift.io
@@ -97,6 +101,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: cluster-autoscaler-operator
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 subjects:
 - kind: ServiceAccount
   name: cluster-autoscaler-operator
@@ -111,6 +117,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cluster-autoscaler-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -126,6 +134,8 @@ kind: ServiceAccount
 metadata:
   name: cluster-autoscaler-operator
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 
 ---
 apiVersion: v1
@@ -136,6 +146,8 @@ metadata:
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -145,6 +157,8 @@ metadata:
   labels:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups: [""]
   resources: ["events","endpoints"]
@@ -196,6 +210,8 @@ metadata:
   labels:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -213,6 +229,8 @@ metadata:
   labels:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -228,6 +246,8 @@ kind: RoleBinding
 metadata:
   name: cluster-autoscaler
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
@@ -246,6 +266,8 @@ kind: RoleBinding
 metadata:
   name: prometheus-k8s-cluster-autoscaler-operator
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -262,6 +284,8 @@ kind: Role
 metadata:
   name: prometheus-k8s-cluster-autoscaler-operator
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
   - apiGroups:
       - ""

--- a/install/05_configmap.yaml
+++ b/install/05_configmap.yaml
@@ -8,4 +8,5 @@ metadata:
     k8s-app: cluster-autoscaler-operator
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 data:

--- a/install/06_kube_rbac_proxy.yaml
+++ b/install/06_kube_rbac_proxy.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: kube-rbac-proxy-cluster-autoscaler-operator
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 data:
   config-file.yaml: |+
     authorization:

--- a/install/09_alertrules.yaml
+++ b/install/09_alertrules.yaml
@@ -6,6 +6,8 @@ metadata:
     role: alert-rules
   name: cluster-autoscaler-operator-rules
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   groups:
     - name: Cluster-autoscaler-operator-down


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added exclusion annotation so the 4.3 CVO will ignore these operators to stay consistent with 4.2 CVO. As seen here, the 4.3 CVO looks at the value when looking at exclusions https://github.com/openshift/hypershift-toolkit/blob/release-4.3/assets/cluster-version-operator/cluster-version-operator-deployment.yaml#L76-L77

The 4.2 CVO excluded the following operators and resources with those operators https://github.com/openshift/hypershift-toolkit/blob/release-4.2/assets/cluster-version-operator/cluster-version-operator-deployment.yaml#L60-L72
 
**- How to verify it**
Deploy the hypershift toolkit https://github.com/openshift/hypershift-toolkit/tree/release-4.2 and verify that all the resources with this exclusion (exclude.release.openshift.io/internal-openshift-hosted: "true") are not overwriting the ones being deployed into the cluster. 
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
added exclusion to the rest of the resources that the operator manages.