### PR TITLE
BUG 1806438: Drop run-level

### DIFF
--- a/install/00_namespace.yaml
+++ b/install/00_namespace.yaml
@@ -5,6 +5,5 @@ metadata:
   name: openshift-machine-api
   labels:
     name: openshift-machine-api
-    openshift.io/run-level: "1"
     # allow openshift-monitoring to look for ServiceMonitor objects in this namespace
     openshift.io/cluster-monitoring: "true"

--- a/install/07_deployment.yaml
+++ b/install/07_deployment.yaml
@@ -36,7 +36,6 @@ spec:
         - containerPort: 9192
           name: metrics
           protocol: TCP
-        resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         resources:
@@ -105,9 +104,6 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       restartPolicy: Always
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
       tolerations:
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"


### PR DESCRIPTION
cao should follow normal admission control rules for a cluster.
Needs https://github.com/openshift/machine-api-operator/pull/502