### PR TITLE
Bug 1809325: ROKS - remove additional autoscaler manifests

### DIFF
--- a/hack/gen-crd.sh
+++ b/hack/gen-crd.sh
@@ -2,8 +2,18 @@
 
 set -eu
 
-go run ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen crd --domain openshift.io
+function annotate_crd() {
+  script='/^metadata:/a\
+\ \ annotations:\
+\ \ \ \ exclude.release.openshift.io/internal-opernshift-hosted: "true"'
+  input="${1}"
+  output="${2}"
+  sed -e "${script}" "${input}" > "${output}"
+}
+
+go run ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen crd paths=./pkg/apis/...
 
 echo "Copying generated CRDs"
-cp config/crds/autoscaling_v1_clusterautoscaler.yaml install/01_clusterautoscaler.crd.yaml
-cp config/crds/autoscaling_v1beta1_machineautoscaler.yaml install/02_machineautoscaler.crd.yaml
+annotate_crd config/crd/autoscaling.openshift.io_clusterautoscalers.yaml install/01_clusterautoscaler.crd.yaml
+annotate_crd config/crd/autoscaling.openshift.io_machineautoscalers.yaml install/02_machineautoscaler.crd.yaml
+rm -rf ./config/crd

--- a/install/01_clusterautoscaler.crd.yaml
+++ b/install/01_clusterautoscaler.crd.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: clusterautoscalers.autoscaling.openshift.io
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   group: autoscaling.openshift.io
   names:

--- a/install/02_machineautoscaler.crd.yaml
+++ b/install/02_machineautoscaler.crd.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: machineautoscalers.autoscaling.openshift.io
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   additionalPrinterColumns:
   - JSONPath: .spec.scaleTargetRef.kind

--- a/install/09_alertrules.yaml
+++ b/install/09_alertrules.yaml
@@ -6,6 +6,8 @@ metadata:
     role: alert-rules
   name: cluster-autoscaler-operator-rules
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   groups:
     - name: Cluster-autoscaler-operator-down


### PR DESCRIPTION
Remove prometheus rule and autoscaler CRD that should not be present in a hosted
control plane deployment.