### PR TITLE
BUG 1813069: Drop ClusterAutoscalerNodesNotReady alert

### DIFF
--- a/pkg/controller/clusterautoscaler/monitoring.go
+++ b/pkg/controller/clusterautoscaler/monitoring.go
@@ -181,17 +181,6 @@ func (r *Reconciler) AutoscalerPrometheusRule(ca *autoscalingv1.ClusterAutoscale
 							},
 						},
 						{
-							Alert: "ClusterAutoscalerNodesNotReady",
-							Expr:  intstr.FromString("cluster_autoscaler_nodes_count{state!=\"ready\"} > 0"),
-							For:   "20m",
-							Labels: map[string]string{
-								"severity": "warning",
-							},
-							Annotations: map[string]string{
-								"message": "Cluster Autoscaler has {{ $value }} unready nodes",
-							},
-						},
-						{
 							Alert: "ClusterAutoscalerNotSafeToScale",
 							Expr:  intstr.FromString(fmt.Sprintf("cluster_autoscaler_cluster_safe_to_autoscale{service=\"%s\"} != 1", namespacedName.Name)),
 							For:   "15m",


### PR DESCRIPTION
cluster_autoscaler_nodes_count records the total number of "Autoscaler nodes" (i.e expected candidates to join the cluster), labeled by node state. Possible states are ready, unready, notStarted
https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/proposals/metrics.md#cluster-state

The alert triggers if there's a least one node labeled different than "ready" in the "nodes_count" for more than 20min https://github.com/openshift/cluster-autoscaler-operator/blob/8e6f95038c9eee84ef7e305e2e1f4960c918b30d/pkg/controller/clusterautoscaler/monitoring.go#L184

This alert might be triggering for periods where constant increase/decrease of workload happens resulting in constant scale in/out of the cluster.

An "Autoscaler nodes" is always backed by a machine resource. Since we have particular alerts for machines orthogonal to the autoscaler https://github.com/openshift/machine-api-operator/blob/master/install/0000_90_machine-api-operator_04_alertrules.yaml#L23 which covers machines not getting to become nodes and there must be kubelet/node healthiness alerts covered by node team. Therefore we are dropping the one created by the autoscaler as it's introducing confusion and noise.