### PR TITLE
Set clusterapi flag and env variable for group

### DIFF
--- a/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
@@ -32,6 +32,8 @@ const (
 	controllerName      = "cluster_autoscaler_controller"
 	caServiceAccount    = "cluster-autoscaler"
 	caPriorityClassName = "system-cluster-critical"
+	CAPIGroupEnvVar     = "CAPI_GROUP"
+	CAPIGroup           = "machine.openshift.io"
 )
 
 // NewReconciler returns a new Reconciler.
@@ -396,6 +398,12 @@ func (r *Reconciler) AutoscalerPodSpec(ca *autoscalingv1.ClusterAutoscaler) *cor
 					{
 						Name:          "metrics",
 						ContainerPort: 8085,
+					},
+				},
+				Env: []corev1.EnvVar{
+					{
+						Name:  CAPIGroupEnvVar,
+						Value: CAPIGroup,
 					},
 				},
 			},

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -41,7 +41,7 @@ const (
 
 	// DefaultClusterAutoscalerCloudProvider is the default name for
 	// the CloudProvider beeing used.
-	DefaultClusterAutoscalerCloudProvider = "openshift-machine-api"
+	DefaultClusterAutoscalerCloudProvider = "clusterapi"
 
 	// DefaultClusterAutoscalerVerbosity is the default logging
 	// verbosity level for ClusterAutoscaler deployments.


### PR DESCRIPTION
Since we merged the clusterapi provider upstream we are now consuming that directly https://github.com/openshift/kubernetes-autoscaler/pull/139
This is to minimise the commits we need to carry on top by using the upstream flag/env variables.