### PR TITLE
Bug 1796412: cluster-reader is unable to view machine resources

### DIFF
--- a/install/10_cluster_reader_rbac.yaml
+++ b/install/10_cluster_reader_rbac.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-autoscaler-operator:cluster-reader
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+- apiGroups:
+  - autoscaling.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
Added cluster-reader permissions to `cluster-autoscaler` cluster-role