### PR TITLE
Remove verify-actuator-pkg.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,6 @@ push:
 .PHONY: check
 check: fmt vet lint test ## Check your code
 
-.PHONY: check-pkg
-check-pkg:
-	./hack/verify-actuator-pkg.sh
-
 .PHONY: test
 test: ## Run unit tests
 	$(DOCKER_CMD) go test -race -cover ./...

--- a/hack/verify-actuator-pkg.sh
+++ b/hack/verify-actuator-pkg.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -e
-
-


### PR DESCRIPTION
CI stopped using it almost 1 year ago since
https://github.com/openshift/release/pull/4060/commits/cd154392fad5bb511