### PR TITLE
pkg/operator/status: Change ReasonEmpty to ReasonAsExpected

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -22,7 +22,7 @@ import (
 
 // Reason messages used in status conditions.
 const (
-	ReasonEmpty             = ""
+	ReasonAsExpected        = "AsExpected"
 	ReasonMissingDependency = "MissingDependency"
 	ReasonSyncing           = "SyncingResources"
 	ReasonCheckAutoscaler   = "UnableToCheckAutoscalers"
@@ -344,7 +344,7 @@ func (r *StatusReporter) ReportStatus() (bool, error) {
 	}
 
 	msg := fmt.Sprintf("at version %s", r.config.ReleaseVersion)
-	if err := r.available(ReasonEmpty, msg); err != nil {
+	if err := r.available(ReasonAsExpected, msg); err != nil {
 		return false, err
 	}
 


### PR DESCRIPTION
We've used `ReasonEmpty` since 72cd9c4d76 (#23).  But if we feel like we have a message we want to set to help humans understand the condition, we should be setting a reason string for machines too.  AsExpected follows [the library-go precedent][1].

[1]: https://github.com/openshift/library-go/blob/94c59dec54be25c8527e51e8c0a885712aeb01b5/pkg/operator/status/condition.go#L67