### PR TITLE
Bug 1866200: fix recording rules group name

### DIFF
--- a/pkg/controller/clusterautoscaler/monitoring.go
+++ b/pkg/controller/clusterautoscaler/monitoring.go
@@ -167,7 +167,7 @@ func (r *Reconciler) AutoscalerPrometheusRule(ca *autoscalingv1.ClusterAutoscale
 		Spec: monitoringv1.PrometheusRuleSpec{
 			Groups: []monitoringv1.RuleGroup{
 				{
-					Name: "general.rules",
+					Name: "cluster-autoscaler-operator.rules",
 					Rules: []monitoringv1.Rule{
 						{
 							Alert: "ClusterAutoscalerUnschedulablePods",


### PR DESCRIPTION
The `general.rules` group name conflicts with others, causing them to be merged with other rules in OpenShift console via Thanos Querier.

This fixes it.

/cc @openshift/openshift-team-monitoring 