### PR TITLE
Bug 1872080: Create Dockerfile.rhel file

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,12 @@
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 AS builder
+WORKDIR /go/src/github.com/openshift/cluster-autoscaler-operator
+COPY . .
+ENV NO_DOCKER=1
+ENV BUILD_DEST=/go/bin/cluster-autoscaler-operator
+RUN unset VERSION && make build
+
+FROM registry.svc.ci.openshift.org/ocp/4.6:base
+COPY --from=builder /go/bin/cluster-autoscaler-operator /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-autoscaler-operator/install /manifests
+CMD ["/usr/bin/cluster-autoscaler-operator"]
+LABEL io.openshift.release.operator true

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,12 +1,1 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 AS builder
-WORKDIR /go/src/github.com/openshift/cluster-autoscaler-operator
-COPY . .
-ENV NO_DOCKER=1
-ENV BUILD_DEST=/go/bin/cluster-autoscaler-operator
-RUN unset VERSION && make build
-
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
-COPY --from=builder /go/bin/cluster-autoscaler-operator /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/cluster-autoscaler-operator/install /manifests
-CMD ["/usr/bin/cluster-autoscaler-operator"]
-LABEL io.openshift.release.operator true
+Dockerfile.rhel


### PR DESCRIPTION
This creates a Dockerfile.rhel file according to convention and symlink Dockerfile.rhel7 to the new one to satisfy tooling consumers until we switch them