### PR TITLE
Bug 1875036: remove Dockerfile.rhel7

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,1 +1,0 @@
-Dockerfile.rhel


### PR DESCRIPTION
This change removes the now deprecated Dockerfile.rhel7 in favor of the
new Dockerfile.rhel file.