### PR TITLE
Bug 1879162: ensure full boolean arguments

### DIFF
--- a/pkg/controller/clusterautoscaler/clusterautoscaler.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler.go
@@ -84,16 +84,16 @@ func AutoscalerArgs(ca *v1.ClusterAutoscaler, cfg *Config) []string {
 		args = append(args, ScaleDownArgs(s.ScaleDown)...)
 	}
 
-	if ca.Spec.BalanceSimilarNodeGroups != nil && *ca.Spec.BalanceSimilarNodeGroups {
-		args = append(args, BalanceSimilarNodeGroupsArg.String())
+	if ca.Spec.BalanceSimilarNodeGroups != nil {
+		args = append(args, BalanceSimilarNodeGroupsArg.Value(*ca.Spec.BalanceSimilarNodeGroups))
 	}
 
-	if ca.Spec.IgnoreDaemonsetsUtilization != nil && *ca.Spec.IgnoreDaemonsetsUtilization {
-		args = append(args, IgnoreDaemonsetsUtilization.String())
+	if ca.Spec.IgnoreDaemonsetsUtilization != nil {
+		args = append(args, IgnoreDaemonsetsUtilization.Value(*ca.Spec.IgnoreDaemonsetsUtilization))
 	}
 
-	if ca.Spec.SkipNodesWithLocalStorage != nil && *ca.Spec.SkipNodesWithLocalStorage {
-		args = append(args, SkipNodesWithLocalStorage.String())
+	if ca.Spec.SkipNodesWithLocalStorage != nil {
+		args = append(args, SkipNodesWithLocalStorage.Value(*ca.Spec.SkipNodesWithLocalStorage))
 	}
 
 	return args

--- a/pkg/controller/clusterautoscaler/clusterautoscaler_test.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_test.go
@@ -169,9 +169,32 @@ func TestAutoscalerArgEnabled(t *testing.T) {
 	args := AutoscalerArgs(ca, &Config{CloudProvider: TestCloudProvider, Namespace: TestNamespace})
 
 	expected := []string{
-		fmt.Sprintf("--balance-similar-node-groups"),
-		fmt.Sprintf("--ignore-daemonsets-utilization"),
-		fmt.Sprintf("--skip-nodes-with-local-storage"),
+		"--balance-similar-node-groups=true",
+		"--ignore-daemonsets-utilization=true",
+		"--skip-nodes-with-local-storage=true",
+	}
+
+	for _, e := range expected {
+		if !includeString(args, e) {
+			t.Fatalf("missing arg: %s", e)
+		}
+	}
+}
+
+// TestAutoscalerArgEnabledWithFalse validates that args appear in the autoscaler args when
+// set to false in the ClusterAutoscalerSpec.
+func TestAutoscalerArgEnabledWithFalse(t *testing.T) {
+	ca := NewClusterAutoscaler()
+	ca.Spec.BalanceSimilarNodeGroups = pointer.BoolPtr(false)
+	ca.Spec.IgnoreDaemonsetsUtilization = pointer.BoolPtr(false)
+	ca.Spec.SkipNodesWithLocalStorage = pointer.BoolPtr(false)
+
+	args := AutoscalerArgs(ca, &Config{CloudProvider: TestCloudProvider, Namespace: TestNamespace})
+
+	expected := []string{
+		"--balance-similar-node-groups=false",
+		"--ignore-daemonsets-utilization=false",
+		"--skip-nodes-with-local-storage=false",
 	}
 
 	for _, e := range expected {


### PR DESCRIPTION
Currently we did not place boolean arguments if they were not true,
which didn't allow to set an option to false.

While some arguments might be true by default (SkipNodesWithLocalStorage)
others (balanceSimilarNodeGroups) are false by default. So let's
set the value explicitely for the few boolean values.