### PR TITLE
Updating ose-cluster-autoscaler-operator builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,11 +1,11 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-autoscaler-operator
 COPY . .
 ENV NO_DOCKER=1
 ENV BUILD_DEST=/go/bin/cluster-autoscaler-operator
 RUN unset VERSION && make build
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 COPY --from=builder /go/bin/cluster-autoscaler-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cluster-autoscaler-operator/install /manifests
 CMD ["/usr/bin/cluster-autoscaler-operator"]


### PR DESCRIPTION
Updating ose-cluster-autoscaler-operator builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/ose-cluster-autoscaler-operator.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.