### PR TITLE
add bugzilla component to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,5 @@
+component: "Cloud Compute"
+subcomponent: "Other Providers"
 approvers:
   - enxebre
   - frobware


### PR DESCRIPTION
This change adds the bugzilla component name to the OWNERS file to
comply with the prodsec requirements for OpenShift builds through ART.