### PR TITLE
Bug 1876469: Update generated CRDs

### DIFF
--- a/hack/gen-crd.sh
+++ b/hack/gen-crd.sh
@@ -3,12 +3,12 @@
 set -eu
 
 function annotate_crd() {
-  script='/^metadata:/a\
-\ \ annotations:\
+  script1='/^  annotations:/a\
 \ \ \ \ exclude.release.openshift.io/internal-openshift-hosted: "true"'
+  script2='/^    controller-gen.kubebuilder.io\/version: .*$/d'
   input="${1}"
   output="${2}"
-  sed -e "${script}" "${input}" > "${output}"
+  sed -e "${script1}" -e "${script2}" "${input}" > "${output}"
 }
 
 go run ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen crd:crdVersions=v1 paths=./pkg/apis/...

--- a/install/01_clusterautoscaler.crd.yaml
+++ b/install/01_clusterautoscaler.crd.yaml
@@ -24,14 +24,10 @@ spec:
         description: ClusterAutoscaler is the Schema for the clusterautoscalers API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -39,22 +35,13 @@ spec:
             description: Desired state of ClusterAutoscaler resource
             properties:
               balanceSimilarNodeGroups:
-                description: BalanceSimilarNodeGroups enables/disables the `--balance-similar-node-groups`
-                  cluster-autocaler feature. This feature will automatically identify
-                  node groups with the same instance type and the same set of labels
-                  and try to keep the respective sizes of those node groups balanced.
+                description: BalanceSimilarNodeGroups enables/disables the `--balance-similar-node-groups` cluster-autocaler feature. This feature will automatically identify node groups with the same instance type and the same set of labels and try to keep the respective sizes of those node groups balanced.
                 type: boolean
               ignoreDaemonsetsUtilization:
-                description: Enables/Disables `--ignore-daemonsets-utilization` CA
-                  feature flag. Should CA ignore DaemonSet pods when calculating resource
-                  utilization for scaling down. false by default
+                description: Enables/Disables `--ignore-daemonsets-utilization` CA feature flag. Should CA ignore DaemonSet pods when calculating resource utilization for scaling down. false by default
                 type: boolean
               maxNodeProvisionTime:
-                description: Maximum time CA waits for node to be provisioned.
-                             Expects an unsigned duration string of decimal
-                             numbers each with optional fraction and a unit
-                             suffix, eg "300ms", "1.5h" or "2h45m". Valid time
-                             units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+                description: Maximum time CA waits for node to be provisioned
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
               maxPodGracePeriod:
@@ -62,18 +49,14 @@ spec:
                 format: int32
                 type: integer
               podPriorityThreshold:
-                description: 'To allow users to schedule "best-effort" pods, which
-                  shouldn''t trigger Cluster Autoscaler actions, but only run when
-                  there are spare resources available, More info: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption'
+                description: 'To allow users to schedule "best-effort" pods, which shouldn''t trigger Cluster Autoscaler actions, but only run when there are spare resources available, More info: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption'
                 format: int32
                 type: integer
               resourceLimits:
                 description: Constraints of autoscaling resources
                 properties:
                   cores:
-                    description: Minimum and maximum number of cores in cluster, in
-                      the format <min>:<max>. Cluster autoscaler will not scale the
-                      cluster beyond these numbers.
+                    description: Minimum and maximum number of cores in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.
                     properties:
                       max:
                         format: int32
@@ -87,10 +70,7 @@ spec:
                     - min
                     type: object
                   gpus:
-                    description: Minimum and maximum number of different GPUs in cluster,
-                      in the format <gpu_type>:<min>:<max>. Cluster autoscaler will
-                      not scale the cluster beyond these numbers. Can be passed multiple
-                      times.
+                    description: Minimum and maximum number of different GPUs in cluster, in the format <gpu_type>:<min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers. Can be passed multiple times.
                     items:
                       properties:
                         max:
@@ -111,15 +91,12 @@ spec:
                       type: object
                     type: array
                   maxNodesTotal:
-                    description: Maximum number of nodes in all node groups. Cluster
-                      autoscaler will not grow the cluster beyond this number.
+                    description: Maximum number of nodes in all node groups. Cluster autoscaler will not grow the cluster beyond this number.
                     format: int32
                     minimum: 0
                     type: integer
                   memory:
-                    description: Minimum and maximum number of gigabytes of memory
-                      in cluster, in the format <min>:<max>. Cluster autoscaler will
-                      not scale the cluster beyond these numbers.
+                    description: Minimum and maximum number of gigabytes of memory in cluster, in the format <min>:<max>. Cluster autoscaler will not scale the cluster beyond these numbers.
                     properties:
                       max:
                         format: int32
@@ -137,36 +114,29 @@ spec:
                 description: Configuration of scale down operation
                 properties:
                   delayAfterAdd:
-                    description: How long after scale up that scale down evaluation
-                      resumes
+                    description: How long after scale up that scale down evaluation resumes
                     pattern: ([0-9]*(\.[0-9]*)?[a-z]+)+
                     type: string
                   delayAfterDelete:
-                    description: How long after node deletion that scale down evaluation
-                      resumes, defaults to scan-interval
+                    description: How long after node deletion that scale down evaluation resumes, defaults to scan-interval
                     pattern: ([0-9]*(\.[0-9]*)?[a-z]+)+
                     type: string
                   delayAfterFailure:
-                    description: How long after scale down failure that scale down
-                      evaluation resumes
+                    description: How long after scale down failure that scale down evaluation resumes
                     pattern: ([0-9]*(\.[0-9]*)?[a-z]+)+
                     type: string
                   enabled:
                     description: Should CA scale down the cluster
                     type: boolean
                   unneededTime:
-                    description: How long a node should be unneeded before it is eligible
-                      for scale down
+                    description: How long a node should be unneeded before it is eligible for scale down
                     pattern: ([0-9]*(\.[0-9]*)?[a-z]+)+
                     type: string
                 required:
                 - enabled
                 type: object
               skipNodesWithLocalStorage:
-                description: Enables/Disables `--skip-nodes-with-local-storage` CA
-                  feature flag. If true cluster autoscaler will never delete nodes
-                  with pods with local storage, e.g. EmptyDir or HostPath. true by
-                  default at autoscaler
+                description: Enables/Disables `--skip-nodes-with-local-storage` CA feature flag. If true cluster autoscaler will never delete nodes with pods with local storage, e.g. EmptyDir or HostPath. true by default at autoscaler
                 type: boolean
             type: object
           status:

--- a/install/02_machineautoscaler.crd.yaml
+++ b/install/02_machineautoscaler.crd.yaml
@@ -45,14 +45,10 @@ spec:
         description: MachineAutoscaler is the Schema for the machineautoscalers API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -60,14 +56,12 @@ spec:
             description: Specification of constraints of a scalable resource
             properties:
               maxReplicas:
-                description: MaxReplicas constrains the maximal number of replicas
-                  of a scalable resource
+                description: MaxReplicas constrains the maximal number of replicas of a scalable resource
                 format: int32
                 minimum: 1
                 type: integer
               minReplicas:
-                description: MinReplicas constrains the minimal number of replicas
-                  of a scalable resource
+                description: MinReplicas constrains the minimal number of replicas of a scalable resource
                 format: int32
                 minimum: 0
                 type: integer
@@ -75,21 +69,14 @@ spec:
                 description: ScaleTargetRef holds reference to a scalable resource
                 properties:
                   apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources'
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                     type: string
                   kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds'
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     minLength: 1
                     type: string
                   name:
-                    description: Name specifies a name of an object, e.g. worker-us-east-1a.
-                      Scalable resources are expected to exist under a single namespace.
+                    description: Name specifies a name of an object, e.g. worker-us-east-1a. Scalable resources are expected to exist under a single namespace.
                     minLength: 1
                     type: string
                 required:
@@ -105,25 +92,17 @@ spec:
             description: Most recently observed status of a scalable resource
             properties:
               lastTargetRef:
-                description: LastTargetRef holds reference to the recently observed
-                  scalable resource
+                description: LastTargetRef holds reference to the recently observed scalable resource
                 properties:
                   apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources'
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                     type: string
                   kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds'
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     minLength: 1
                     type: string
                   name:
-                    description: Name specifies a name of an object, e.g. worker-us-east-1a.
-                      Scalable resources are expected to exist under a single namespace.
+                    description: Name specifies a name of an object, e.g. worker-us-east-1a. Scalable resources are expected to exist under a single namespace.
                     minLength: 1
                     type: string
                 required:

--- a/pkg/apis/autoscaling/v1beta1/machineautoscaler_types.go
+++ b/pkg/apis/autoscaling/v1beta1/machineautoscaler_types.go
@@ -65,13 +65,13 @@ type CrossVersionObjectReference struct {
 	// APIVersion defines the versioned schema of this representation of an
 	// object. Servers should convert recognized schemas to the latest internal
 	// value, and may reject unrecognized values. More info:
-	// http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources
+	// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 	APIVersion string `json:"apiVersion,omitempty"`
 
 	// Kind is a string value representing the REST resource this object
 	// represents. Servers may infer this from the endpoint the client submits
 	// requests to. Cannot be updated. In CamelCase. More info:
-	// http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds
+	// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	// +kubebuilder:validation:MinLength=1
 	Kind string `json:"kind"`
 


### PR DESCRIPTION
This ensures that CRD generation is up to date and that newer links are included in descriptions for core typemeta/metadata fields