### PR TITLE
add current profile annotations to CVO manifests

### DIFF
--- a/install/03_rbac.yaml
+++ b/install/03_rbac.yaml
@@ -42,6 +42,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: cluster-autoscaler-operator
   namespace: openshift-machine-api
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 rules:
 - apiGroups:
   - autoscaling.openshift.io
@@ -99,6 +101,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: cluster-autoscaler-operator
   namespace: openshift-machine-api
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 subjects:
 - kind: ServiceAccount
   name: cluster-autoscaler-operator
@@ -113,6 +117,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cluster-autoscaler-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -128,6 +134,8 @@ kind: ServiceAccount
 metadata:
   name: cluster-autoscaler-operator
   namespace: openshift-machine-api
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 
 ---
 apiVersion: v1
@@ -138,6 +146,8 @@ metadata:
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
   namespace: openshift-machine-api
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -147,6 +157,8 @@ metadata:
   labels:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 rules:
 - apiGroups: [""]
   resources: ["events","endpoints"]
@@ -205,6 +217,8 @@ metadata:
   labels:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -222,6 +236,8 @@ metadata:
   labels:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -240,6 +256,8 @@ metadata:
   labels:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -255,6 +273,8 @@ kind: RoleBinding
 metadata:
   name: prometheus-k8s-cluster-autoscaler-operator
   namespace: openshift-machine-api
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -271,6 +291,8 @@ kind: Role
 metadata:
   name: prometheus-k8s-cluster-autoscaler-operator
   namespace: openshift-machine-api
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 rules:
   - apiGroups:
       - ""


### PR DESCRIPTION
This is matches openshift/enhancements#510 and doesn't change existing behavior

---

It was one of the first repos I changed and I missed the fact that some files can contain multiples manifests.