### PR TITLE
[OCPCLOUD-809] Add verify-diff check in generate task and enable in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ vendor:
 	go mod verify
 
 .PHONY: generate
-generate: gen-deepcopy gen-crd
+generate: gen-deepcopy gen-crd goimports
+	./hack/verify-diff.sh
 
 .PHONY: gen-deepcopy
 gen-deepcopy:

--- a/hack/gen-crd.sh
+++ b/hack/gen-crd.sh
@@ -4,7 +4,8 @@ set -eu
 
 function annotate_crd() {
   script1='/^  annotations:/a\
-\ \ \ \ exclude.release.openshift.io/internal-openshift-hosted: "true"'
+\ \ \ \ exclude.release.openshift.io/internal-openshift-hosted: "true"\
+\ \ \ \ include.release.openshift.io/self-managed-high-availability: "true"'
   script2='/^    controller-gen.kubebuilder.io\/version: .*$/d'
   input="${1}"
   output="${2}"

--- a/hack/verify-diff.sh
+++ b/hack/verify-diff.sh
@@ -1,0 +1,9 @@
+FILE_DIFF=$(git ls-files -o --exclude-standard)
+
+if [ "$FILE_DIFF" != "" ]; then
+  echo "Found untracked files:"
+  echo $FILE_DIFF
+  exit 1
+fi
+
+git diff --exit-code


### PR DESCRIPTION
Allowing automatic make generate checks in CI. It allows to keep track of API changes, client-generated code updates on each PR.

This PR is dependent on openshift/release#13400 to enable the functionality in CI.