### PR TITLE
add 'single-node-production-edge' annotations to CVO manifests.

### DIFF
--- a/hack/gen-crd.sh
+++ b/hack/gen-crd.sh
@@ -5,7 +5,8 @@ set -eu
 function annotate_crd() {
   script1='/^  annotations:/a\
 \ \ \ \ exclude.release.openshift.io/internal-openshift-hosted: "true"\
-\ \ \ \ include.release.openshift.io/self-managed-high-availability: "true"'
+\ \ \ \ include.release.openshift.io/self-managed-high-availability: "true"\
+\ \ \ \ include.release.openshift.io/single-node-production-edge: "true"'
   script2='/^    controller-gen.kubebuilder.io\/version: .*$/d'
   input="${1}"
   output="${2}"

--- a/install/01_clusterautoscaler.crd.yaml
+++ b/install/01_clusterautoscaler.crd.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   creationTimestamp: null
   name: clusterautoscalers.autoscaling.openshift.io
 spec:

--- a/install/02_machineautoscaler.crd.yaml
+++ b/install/02_machineautoscaler.crd.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   creationTimestamp: null
   name: machineautoscalers.autoscaling.openshift.io
 spec:

--- a/install/03_rbac.yaml
+++ b/install/03_rbac.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: cluster-autoscaler-operator
 rules:
 - apiGroups:
@@ -44,6 +45,7 @@ metadata:
   namespace: openshift-machine-api
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - autoscaling.openshift.io
@@ -103,6 +105,7 @@ metadata:
   namespace: openshift-machine-api
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 subjects:
 - kind: ServiceAccount
   name: cluster-autoscaler-operator
@@ -119,6 +122,7 @@ metadata:
   name: cluster-autoscaler-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -136,7 +140,7 @@ metadata:
   namespace: openshift-machine-api
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
-
+    include.release.openshift.io/single-node-production-edge: "true"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -148,7 +152,7 @@ metadata:
   namespace: openshift-machine-api
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
-
+    include.release.openshift.io/single-node-production-edge: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -159,6 +163,7 @@ metadata:
     k8s-app: cluster-autoscaler
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups: [""]
   resources: ["events","endpoints"]
@@ -219,6 +224,7 @@ metadata:
     k8s-app: cluster-autoscaler
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -238,6 +244,7 @@ metadata:
     k8s-app: cluster-autoscaler
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -258,6 +265,7 @@ metadata:
     k8s-app: cluster-autoscaler
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -275,6 +283,7 @@ metadata:
   namespace: openshift-machine-api
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -293,6 +302,7 @@ metadata:
   namespace: openshift-machine-api
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
   - apiGroups:
       - ""

--- a/install/04_service.yaml
+++ b/install/04_service.yaml
@@ -10,6 +10,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     service.beta.openshift.io/serving-cert-secret-name: cluster-autoscaler-operator-cert
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   type: ClusterIP
   ports:

--- a/install/05_kube_rbac_proxy.yaml
+++ b/install/05_kube_rbac_proxy.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-machine-api
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 data:
   config-file.yaml: |+
     authorization:

--- a/install/06_servicemonitor.yaml
+++ b/install/06_servicemonitor.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/install/07_deployment.yaml
+++ b/install/07_deployment.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   replicas: 1
   selector:

--- a/install/08_clusteroperator.yaml
+++ b/install/08_clusteroperator.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 status:
   versions:
   - name: operator

--- a/install/09_alertrules.yaml
+++ b/install/09_alertrules.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   groups:
     - name: Cluster-autoscaler-operator-down

--- a/install/10_cluster_reader_rbac.yaml
+++ b/install/10_cluster_reader_rbac.yaml
@@ -6,6 +6,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - autoscaling.openshift.io


### PR DESCRIPTION
This PR adds annotation for the single-node-production-edge cluster profile. There's a growing requirement from several customers to enable creation of single-node (not high-available) Openshift clusters.
In stage one (following openshift/enhancements#504) there should be no implication on components logic.
In the next stage, the component's behavior will match a non high-availability profile if the customer is specifically interested in one.
This PR is separate from the 'single-node-developer' work, which will implement a different behavior and is currently on another stage of implementation.

For more info, please refer to the enhancement link and participate in the discussion.