### PR TITLE
Bug 1915473: Annotate manifests for single-node-developer cluster profile

### DIFF
--- a/hack/gen-crd.sh
+++ b/hack/gen-crd.sh
@@ -5,7 +5,8 @@ set -eu
 function annotate_crd() {
   script1='/^  annotations:/a\
 \ \ \ \ exclude.release.openshift.io/internal-openshift-hosted: "true"\
-\ \ \ \ include.release.openshift.io/self-managed-high-availability: "true"'
+\ \ \ \ include.release.openshift.io/self-managed-high-availability: "true"\
+\ \ \ \ include.release.openshift.io/single-node-developer: "true"'
   script2='/^    controller-gen.kubebuilder.io\/version: .*$/d'
   input="${1}"
   output="${2}"

--- a/install/01_clusterautoscaler.crd.yaml
+++ b/install/01_clusterautoscaler.crd.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: clusterautoscalers.autoscaling.openshift.io
 spec:

--- a/install/02_machineautoscaler.crd.yaml
+++ b/install/02_machineautoscaler.crd.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   name: machineautoscalers.autoscaling.openshift.io
 spec:

--- a/install/03_rbac.yaml
+++ b/install/03_rbac.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: cluster-autoscaler-operator
 rules:
 - apiGroups:
@@ -44,6 +45,7 @@ metadata:
   namespace: openshift-machine-api
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - autoscaling.openshift.io
@@ -103,6 +105,7 @@ metadata:
   namespace: openshift-machine-api
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 subjects:
 - kind: ServiceAccount
   name: cluster-autoscaler-operator
@@ -119,6 +122,7 @@ metadata:
   name: cluster-autoscaler-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -136,6 +140,7 @@ metadata:
   namespace: openshift-machine-api
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 
 ---
 apiVersion: v1
@@ -148,6 +153,7 @@ metadata:
   namespace: openshift-machine-api
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -159,6 +165,7 @@ metadata:
     k8s-app: cluster-autoscaler
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups: [""]
   resources: ["events","endpoints"]
@@ -219,6 +226,7 @@ metadata:
     k8s-app: cluster-autoscaler
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -238,6 +246,7 @@ metadata:
     k8s-app: cluster-autoscaler
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -258,6 +267,7 @@ metadata:
     k8s-app: cluster-autoscaler
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -275,6 +285,7 @@ metadata:
   namespace: openshift-machine-api
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -293,6 +304,7 @@ metadata:
   namespace: openshift-machine-api
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
   - apiGroups:
       - ""

--- a/install/04_service.yaml
+++ b/install/04_service.yaml
@@ -10,6 +10,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     service.beta.openshift.io/serving-cert-secret-name: cluster-autoscaler-operator-cert
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   type: ClusterIP
   ports:

--- a/install/05_kube_rbac_proxy.yaml
+++ b/install/05_kube_rbac_proxy.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-machine-api
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 data:
   config-file.yaml: |+
     authorization:

--- a/install/06_servicemonitor.yaml
+++ b/install/06_servicemonitor.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/install/07_deployment.yaml
+++ b/install/07_deployment.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   replicas: 1
   selector:

--- a/install/08_clusteroperator.yaml
+++ b/install/08_clusteroperator.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 status:
   versions:
   - name: operator

--- a/install/09_alertrules.yaml
+++ b/install/09_alertrules.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   groups:
     - name: Cluster-autoscaler-operator-down

--- a/install/10_cluster_reader_rbac.yaml
+++ b/install/10_cluster_reader_rbac.yaml
@@ -6,6 +6,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - autoscaling.openshift.io


### PR DESCRIPTION
This partially implements phase 1 of https://github.com/openshift/enhancements#482
and does not change behavior. Initially, all cluster-autoscaler-operator
manifests are included in the single-node-developer cluster profile.
Follow-on PRs may exclude any of these that are not needed in the
profile.