### PR TITLE
Bug 1907380: Reduce verbosity of kube-rbac-proxy logging

### DIFF
--- a/install/07_deployment.yaml
+++ b/install/07_deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --config-file=/etc/kube-rbac-proxy/config-file.yaml
         - --logtostderr=true
-        - --v=10
+        - --v=3
         image: quay.io/openshift/origin-kube-rbac-proxy:4.2.0
         imagePullPolicy: IfNotPresent
         ports:


### PR DESCRIPTION
The Kube RBAC Proxy containers are logging excessively. Having log level 10 includes logging bearer tokens and full http request/responses. This is insecure, more logging than we need, and has an impact on aggregated logging. Reduce to 3 to be inline with other components.