### PR TITLE
Bug 1923823: Improve TLS configuration for Kube RBAC Proxy

### DIFF
--- a/install/07_deployment.yaml
+++ b/install/07_deployment.yaml
@@ -29,6 +29,7 @@ spec:
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --config-file=/etc/kube-rbac-proxy/config-file.yaml
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --logtostderr=true
         - --v=10
         image: quay.io/openshift/origin-kube-rbac-proxy:4.2.0


### PR DESCRIPTION
The default ciphers are not secure and are susceptible to a number of different known vulnerabilities. This collection of ciphers should be more secure and have no known vulnerabilities present.

Suites inspired by the [cluster-monitoring-operator](https://github.com/openshift/cluster-monitoring-operator/blob/f98cd6d7d1dc50fe881c6aa29d772a581451afd1/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml#L54).