### PR TITLE
Bug 1938467: The default cluster-autoscaler should get default cpu and memory requests if user omits them

### DIFF
--- a/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -404,6 +405,12 @@ func (r *Reconciler) AutoscalerPodSpec(ca *autoscalingv1.ClusterAutoscaler) *cor
 					{
 						Name:  CAPIGroupEnvVar,
 						Value: CAPIGroup,
+					},
+				},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20Mi"),
+						corev1.ResourceMemory: resource.MustParse("10m"),
 					},
 				},
 			},


### PR DESCRIPTION
We are missing requests on autoscaler pods which are deployed after `ClusterAutoscaler` resource is created in the cluster.