### PR TITLE
Add management workload annotations

### DIFF
--- a/install/07_deployment.yaml
+++ b/install/07_deployment.yaml
@@ -17,6 +17,8 @@ spec:
       k8s-app: cluster-autoscaler-operator
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: cluster-autoscaler-operator
     spec:

--- a/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
@@ -339,8 +339,9 @@ func (r *Reconciler) AutoscalerDeployment(ca *autoscalingv1.ClusterAutoscaler) *
 	}
 
 	annotations := map[string]string{
-		util.CriticalPodAnnotation:    "",
-		util.ReleaseVersionAnnotation: r.config.ReleaseVersion,
+		util.CriticalPodAnnotation:        "",
+		util.ReleaseVersionAnnotation:     r.config.ReleaseVersion,
+		util.WorkloadManagementAnnotation: util.WorkloadManagementSchedulingPreferred,
 	}
 
 	podSpec := r.AutoscalerPodSpec(ca)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -11,6 +11,11 @@ import (
 const (
 	ReleaseVersionAnnotation = "release.openshift.io/version"
 	CriticalPodAnnotation    = "scheduler.alpha.kubernetes.io/critical-pod"
+
+	// Workload designation annotations as per
+	// https://github.com/openshift/enhancements/blob/master/enhancements/management-workload-partitioning.md
+	WorkloadManagementAnnotation          = "target.workload.openshift.io/management"
+	WorkloadManagementSchedulingPreferred = `{"effect": "PreferredDuringScheduling"}`
 )
 
 // FilterString removes any instances of the needle from haystack.  It


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.