### PR TITLE
Bug 1938467: Fix cluster autoscaler pod requests

### DIFF
--- a/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
@@ -409,8 +409,8 @@ func (r *Reconciler) AutoscalerPodSpec(ca *autoscalingv1.ClusterAutoscaler) *cor
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("20Mi"),
-						corev1.ResourceMemory: resource.MustParse("10m"),
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("20Mi"),
 					},
 				},
 			},


### PR DESCRIPTION
These seem to be the wrong way around and I think this is now causing CI failures