### PR TITLE
Bug 1960554: manifests: use v1 for RBAC

### DIFF
--- a/install/03_rbac.yaml
+++ b/install/03_rbac.yaml
@@ -40,7 +40,7 @@ rules:
 
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cluster-autoscaler-operator
   namespace: openshift-machine-api
@@ -113,7 +113,7 @@ rules:
 
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cluster-autoscaler-operator
   namespace: openshift-machine-api


### PR DESCRIPTION
rbac v1beta1 support was [removed](https://github.com/openshift/cluster-version-operator/pull/565) from CVO, so autoscaler should use v1 RBAC