### PR TITLE
[OCPCLOUD-1174] Add related objects to ClusterOperator

### DIFF
--- a/install/08_clusteroperator.yaml
+++ b/install/08_clusteroperator.yaml
@@ -10,3 +10,13 @@ status:
   versions:
   - name: operator
     version: "0.0.1-snapshot"
+  relatedObjects:
+  - group: ""
+    name: openshift-machine-api
+    resource: namespaces
+  - group: autoscaling.openshift.io
+    name: ""
+    resource: clusterautoscalers
+  - group: autoscaling.openshift.io
+    name: ""
+    resource: machineautoscalers


### PR DESCRIPTION
This change adds the autoscaler specific resources to the
ClusterOperator manifest.