### PR TITLE
[OCPCLOUD-1153] add a tombstones manifest to the install directory

### DIFF
--- a/install/99_tombstones.yaml
+++ b/install/99_tombstones.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-autoscaler-operator-ca
+  namespace: openshift-machine-api
+  annotations:
+    release.openshift.io/delete: "true"
+---
+apiVersion: monitoring.coreos.com
+kind: PrometheusRule
+metadata:
+  name: cluster-autoscaler-operator-rules
+  namespace: openshift-machine-api
+  annotations:
+    release.openshift.io/delete: "true"


### PR DESCRIPTION
CVO has added the ability to remove objects created in previous releases
of OpenShift. This change adds a manifest to remove old objects which
are no longer used by the cluster-autoscaler-operator.

ref: https://issues.redhat.com/browse/OTA-395