### PR TITLE
Bug 1988032: add cvo ha annotation to tombstones

### DIFF
--- a/install/99_tombstones.yaml
+++ b/install/99_tombstones.yaml
@@ -4,12 +4,14 @@ metadata:
   name: cluster-autoscaler-operator-ca
   namespace: openshift-machine-api
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/delete: "true"
 ---
-apiVersion: monitoring.coreos.com
+apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: cluster-autoscaler-operator-rules
   namespace: openshift-machine-api
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/delete: "true"


### PR DESCRIPTION
This change adds the annotation
`include.release.openshift.io/self-managed-high-availability: "true"`
to the tombstones. This is needed to ensure that the CVO will process
them.