### PR TITLE
 [release-4.8] Bug 1995595: add csidrivers and csistoragecapacities to autoscaler cluster role

### DIFF
--- a/install/03_rbac.yaml
+++ b/install/03_rbac.yaml
@@ -221,7 +221,7 @@ rules:
   resources: ["statefulsets","replicasets","daemonsets"]
   verbs: ["watch","list","get"]
 - apiGroups: ["storage.k8s.io"]
-  resources: ["storageclasses", "csinodes"]
+  resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities"]
   verbs: ["watch","list","get"]
 - apiGroups: ["cluster.k8s.io","machine.openshift.io"]
   resources: ["machinedeployments","machines","machinesets","machinesets/scale"]


### PR DESCRIPTION
The autoscaler will need to watch, list, and get these for normal
operation.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1995595