### PR TITLE
Bug 1943194: add logic to detect GPU capacity and update accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The operator manages the following custom resources:
 
 - __MachineAutoscaler__: This resource targets a node group and manages
   the annotations to enable and configure autoscaling for that group,
-  e.g. the min and max size.  Currently only `MachineSet` objects can be
+  e.g. the min and max size, and GPU label.  Currently only `MachineSet` objects can be
   targeted.  ([Example][MachineAutoscaler])
 
 [ClusterAutoscaler]: https://github.com/openshift/cluster-autoscaler-operator/blob/master/examples/clusterautoscaler.yaml

--- a/pkg/controller/machineautoscaler/machineautoscaler_controller.go
+++ b/pkg/controller/machineautoscaler/machineautoscaler_controller.go
@@ -403,9 +403,14 @@ func (r *Reconciler) GetTarget(ref *corev1.ObjectReference) (*MachineTarget, err
 
 // UpdateTarget updates the min and max annotations on the given target.
 func (r *Reconciler) UpdateTarget(target *MachineTarget, min, max int) error {
-	// Update the target object's annotations if necessary.
+	// Update the target object's annotations and labels if necessary.
 	if target.NeedsUpdate(min, max) {
 		target.SetLimits(min, max)
+
+		// TODO (elmiko) remove this code path once all the infrastructure providers support adding the accelerator label
+		if target.HasGPUCapacity() && !target.HasGPUAcceleratorLabel() {
+			target.SetGPUAcceleratorLabel()
+		}
 
 		return r.client.Update(context.TODO(), target.ToUnstructured())
 	}

--- a/pkg/controller/machineautoscaler/machinetarget.go
+++ b/pkg/controller/machineautoscaler/machinetarget.go
@@ -6,10 +6,22 @@ import (
 	"strconv"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	// autoscalerCapacityGPU is the annotation key used by infrastructure providers
+	// to indicate that a machine will have GPU capacity.
+	// ref: https://github.com/openshift/kubernetes-autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go#L41
+	autoscalerCapacityGPU = "machine.openshift.io/GPU"
+	// autoscalerGPUAcceleratorLabel is the label name used by the cluster autoscaler
+	// to indicate that a node will have a GPU, this is to help the autoscaler wait for GPU drivers to be installed
+	// ref: https://github.com/openshift/kubernetes-autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go#L40
+	autoscalerGPUAcceleratorLabel = "cluster-api/accelerator"
 )
 
 var (
@@ -59,8 +71,10 @@ func (mt *MachineTarget) ToUnstructured() *unstructured.Unstructured {
 }
 
 // NeedsUpdate indicates whether a target needs to be updates to match
-// the given min and max values.  An error may be returned if there
-// was an error parsing the current values.
+// the given min and max values. If there is an error reading the current
+// min/max values then this will return true.
+// If the machine target has capacity for GPUs but does not contain the
+// accelerator label then this function will return true.
 func (mt *MachineTarget) NeedsUpdate(min, max int) bool {
 	currentMin, currentMax, err := mt.GetLimits()
 	if err != nil {
@@ -70,7 +84,11 @@ func (mt *MachineTarget) NeedsUpdate(min, max int) bool {
 	minDiff := min != currentMin
 	maxDiff := max != currentMax
 
-	return minDiff || maxDiff
+	// if the machine target has GPU capacity, then it needs a label as well.
+	// but, we only update if the label is missing.
+	needsGPULabel := (mt.HasGPUAcceleratorLabel() == false) && (mt.HasGPUCapacity() == true)
+
+	return minDiff || maxDiff || needsGPULabel
 }
 
 // SetLimits sets the target's min and max annotations.
@@ -221,4 +239,44 @@ func (mt *MachineTarget) NamespacedName() types.NamespacedName {
 		Name:      mt.GetName(),
 		Namespace: mt.GetNamespace(),
 	}
+}
+
+// HasGPUCapacity returns true if the machine target contains the annotation
+// which indicates that the target will have GPU capacity, and that the
+// value is positive.
+func (mt *MachineTarget) HasGPUCapacity() bool {
+	annotations := mt.GetAnnotations()
+	value, found := annotations[autoscalerCapacityGPU]
+	if found {
+		quantityGPU := resource.MustParse(value)
+		numGPU, converted := quantityGPU.AsInt64()
+		if !converted || numGPU < 1 {
+			found = false
+		}
+	}
+	return found
+}
+
+// HasGPUAcceleratorLabel returns true if the machine target contains the
+// label to indicate that the autoscaler should expect nodes from this
+// target to contain GPUs.
+func (mt *MachineTarget) HasGPUAcceleratorLabel() bool {
+	labels := mt.GetLabels()
+	// the value of this label is not used, only its presence
+	_, found := labels[autoscalerGPUAcceleratorLabel]
+	return found
+}
+
+// SetGPUAcceleratorLabel adds the label to inform the autoscaler that it
+// should expect nodes from this target to contain GPUs.
+func (mt *MachineTarget) SetGPUAcceleratorLabel() {
+	labels := mt.GetLabels()
+
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	labels[autoscalerGPUAcceleratorLabel] = ""
+
+	mt.SetLabels(labels)
 }

--- a/pkg/controller/machineautoscaler/machinetarget_test.go
+++ b/pkg/controller/machineautoscaler/machinetarget_test.go
@@ -54,12 +54,12 @@ func TestNeedsUpdate(t *testing.T) {
 
 	// Different min and max.
 	if !target.NeedsUpdate(2, 4) {
-		t.Fatal("target should need update")
+		t.Fatal("target should need update, different min/max")
 	}
 
 	// Same min and max.
 	if target.NeedsUpdate(4, 6) {
-		t.Fatal("target should not need update")
+		t.Fatal("target should not need update, same min/max")
 	}
 
 	target.SetAnnotations(map[string]string{
@@ -69,7 +69,31 @@ func TestNeedsUpdate(t *testing.T) {
 
 	// Error parsing values.
 	if !target.NeedsUpdate(1, 2) {
-		t.Fatal("target should need update")
+		t.Fatal("target should need update, error parsing values")
+	}
+
+	// set the gpu capacity, and reset the min/max
+	target.SetAnnotations(map[string]string{
+		autoscalerCapacityGPU: "1",
+	})
+	target.SetLimits(4, 6)
+	if !target.NeedsUpdate(4, 6) {
+		t.Errorf("target should need update, gpu capacity with no label")
+	}
+
+	// add label
+	target.SetLabels(map[string]string{
+		autoscalerGPUAcceleratorLabel: "",
+	})
+	if target.NeedsUpdate(4, 6) {
+		t.Errorf("target should not need an update, gpu capacity with label")
+	}
+
+	// reset the gpu capacity
+	target.SetAnnotations(map[string]string{})
+	target.SetLimits(4, 6)
+	if target.NeedsUpdate(4, 6) {
+		t.Errorf("target should not need an update, no gpu capacity with label")
 	}
 }
 
@@ -281,5 +305,59 @@ func TestNamespacedName(t *testing.T) {
 	if nn.Namespace != TargetNamespace {
 		t.Errorf("NamespacedName() returned bad namespace. Got: %s, Want: %s",
 			nn.Namespace, TargetNamespace)
+	}
+}
+
+func TestHasGPUCapacity(t *testing.T) {
+	target := NewTarget()
+	target.SetAnnotations(map[string]string{
+		autoscalerCapacityGPU: "1",
+	})
+
+	if !target.HasGPUCapacity() {
+		t.Error("HasGPUCapacity returned false when true was expected, 1 GPU")
+	}
+
+	target.SetAnnotations(map[string]string{
+		autoscalerCapacityGPU: "0",
+	})
+
+	if target.HasGPUCapacity() {
+		t.Error("HasGPUCapacity returned true when false was expected, 0 GPU")
+	}
+
+	target.SetAnnotations(map[string]string{
+		autoscalerCapacityGPU: "-1",
+	})
+
+	if target.HasGPUCapacity() {
+		t.Error("HasGPUCapacity returned true when false was expected, -1 GPU")
+	}
+}
+
+func TestHasGPUAcceleratorLabel(t *testing.T) {
+	target := NewTarget()
+	if target.HasGPUAcceleratorLabel() {
+		t.Error("HasGPUAcceleratorLabel return true when false was expected, no label")
+	}
+
+	target.SetLabels(map[string]string{
+		autoscalerGPUAcceleratorLabel: "",
+	})
+	if !target.HasGPUAcceleratorLabel() {
+		t.Error("HasGPUAcceleratorLabel return false when true was expected, label present")
+	}
+}
+
+func TestSetGPUAcceleratorLabel(t *testing.T) {
+	target := NewTarget()
+
+	if target.HasGPUAcceleratorLabel() {
+		t.Error("Target has GPU accelerator label when not expected")
+	}
+
+	target.SetGPUAcceleratorLabel()
+	if !target.HasGPUAcceleratorLabel() {
+		t.Error("Target does not have GPU accelerator label when expected")
 	}
 }


### PR DESCRIPTION
This change adds several functions to test whether a MachineSet has
capacity for GPUs on the Machines, and then applies a GPU accelerator
label, where appropriate, to the MachineSet. This label will help the
autoscaler to utilize its GPU custom node processor which will force the
autoscaler to wait for GPU drivers to be deployed before adding more
nodes. This alleviates a condition whereby the autoscaler can create too
many nodes for GPU workloads.