### PR TITLE
Bug 2001027: add topology.ebs.csi.aws.com/zone to ignored labels

### DIFF
--- a/pkg/controller/clusterautoscaler/clusterautoscaler.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler.go
@@ -52,6 +52,7 @@ const (
 	BalanceSimilarNodeGroupsArg     AutoscalerArg = "--balance-similar-node-groups"
 	IgnoreDaemonsetsUtilization     AutoscalerArg = "--ignore-daemonsets-utilization"
 	SkipNodesWithLocalStorage       AutoscalerArg = "--skip-nodes-with-local-storage"
+	BalancingIgnoreLabel            AutoscalerArg = "--balancing-ignore-label"
 )
 
 // AutoscalerArgs returns a slice of strings representing command line arguments
@@ -92,6 +93,12 @@ func AutoscalerArgs(ca *v1.ClusterAutoscaler, cfg *Config) []string {
 
 	if ca.Spec.BalanceSimilarNodeGroups != nil {
 		args = append(args, BalanceSimilarNodeGroupsArg.Value(*ca.Spec.BalanceSimilarNodeGroups))
+		// if we are enabling the balance similar node groups option, we need to ignore
+		// openshift specific labels that prevent the default balancing behavior.
+		// TODO (elmiko) remove this label once it has been fully deprecated from the aws-ebs-csi-driver
+		if *ca.Spec.BalanceSimilarNodeGroups == true {
+			args = append(args, BalancingIgnoreLabel.Value("topology.ebs.csi.aws.com/zone"))
+		}
 	}
 
 	if ca.Spec.IgnoreDaemonsetsUtilization != nil {


### PR DESCRIPTION
when balancing similar nodes, the autoscaler will look for differences
in labels as one of its checks for similarity. by default it will ignore
the well known kubernetes zone label (topology.kubernetes.io/zone), but
the aws-ebs-csi-driver will add a unique label for its zone,
`topology.ebs.csi.aws.com/zone`. this label will eventually be
deprecated in favor of the common well known topology label. for more
information about this see the references.

ref: kubernetes/autoscaler#3230
ref: kubernetes-sigs/aws-ebs-csi-driver#729