### PR TITLE
Bug 2025230: Change ClusterAutoscalerUnschedulablePods severity to info

### DIFF
--- a/pkg/controller/clusterautoscaler/monitoring.go
+++ b/pkg/controller/clusterautoscaler/monitoring.go
@@ -174,7 +174,7 @@ func (r *Reconciler) AutoscalerPrometheusRule(ca *autoscalingv1.ClusterAutoscale
 							Expr:  intstr.FromString(fmt.Sprintf("cluster_autoscaler_unschedulable_pods_count{service=\"%s\"} > 0", namespacedName.Name)),
 							For:   "20m",
 							Labels: map[string]string{
-								"severity": "warning",
+								"severity": "info",
 							},
 							Annotations: map[string]string{
 								"message": "Cluster Autoscaler has {{ $value }} unschedulable pods",


### PR DESCRIPTION
This alert is informational for the cluster operator, and doesn't describe an actual problematic condition that requires human action.

Per the documentation:
> In many cases this alert is normal and expected depending on the configuration of the autoscaler.

As such, lowering the severity of this to "info".