### PR TITLE
add capi version to autoscaler deployment

### DIFF
--- a/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
@@ -35,6 +35,8 @@ const (
 	caPriorityClassName = "system-cluster-critical"
 	CAPIGroupEnvVar     = "CAPI_GROUP"
 	CAPIGroup           = "machine.openshift.io"
+	CAPIVersionEnvVar   = "CAPI_VERSION"
+	CAPIVersion         = "v1beta1"
 )
 
 // NewReconciler returns a new Reconciler.
@@ -419,6 +421,10 @@ func (r *Reconciler) AutoscalerPodSpec(ca *autoscalingv1.ClusterAutoscaler) *cor
 					{
 						Name:  CAPIGroupEnvVar,
 						Value: CAPIGroup,
+					},
+					{
+						Name:  CAPIVersionEnvVar,
+						Value: CAPIVersion,
 					},
 				},
 				Resources: corev1.ResourceRequirements{


### PR DESCRIPTION
This change adds the `CAPI_VERSION` environment variable to the
container spec for the cluster autoscaler, set to `v1beta1`. It is being
added to better scope the resources that the autoscaler watches, and to
mitigate unwanted `v1` objects from being selected.