### PR TITLE
Add client certificate and key to service monitor

### DIFF
--- a/install/06_servicemonitor.yaml
+++ b/install/06_servicemonitor.yaml
@@ -18,6 +18,8 @@ spec:
       tlsConfig:
         caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
         serverName: cluster-autoscaler-operator.openshift-machine-api.svc
+        certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+        keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   namespaceSelector:
     matchNames:
       - openshift-machine-api


### PR DESCRIPTION
Added client certificates based on https://github.com/deads2k/openshift-enhancements/blob/master/enhancements/monitoring/client-cert-scraping.md