### PR TITLE
OCPCLOUD-1677: add flag for duplicated events

### DIFF
--- a/pkg/controller/clusterautoscaler/clusterautoscaler.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler.go
@@ -42,6 +42,7 @@ func (a AutoscalerArg) TypeRange(t string, min, max int) string {
 // operator when processing ClusterAutoscaler resources.
 const (
 	LogToStderrArg                   AutoscalerArg = "--logtostderr"
+	RecordDuplicatedEventsArg        AutoscalerArg = "--record-duplicated-events"
 	NamespaceArg                     AutoscalerArg = "--namespace"
 	CloudProviderArg                 AutoscalerArg = "--cloud-provider"
 	MaxGracefulTerminationSecArg     AutoscalerArg = "--max-graceful-termination-sec"
@@ -74,6 +75,7 @@ func AutoscalerArgs(ca *v1.ClusterAutoscaler, cfg *Config) []string {
 
 	args := []string{
 		LogToStderrArg.String(),
+		RecordDuplicatedEventsArg.String(),
 		CloudProviderArg.Value(cfg.CloudProvider),
 		NamespaceArg.Value(cfg.Namespace),
 		LeaderElectLeaseDurationArg.Value(leaderElectLeaseDuration),

--- a/pkg/controller/clusterautoscaler/clusterautoscaler_test.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_test.go
@@ -135,6 +135,7 @@ func TestAutoscalerArgs(t *testing.T) {
 
 	defaults := []string{
 		"--logtostderr",
+		"--record-duplicated-events",
 		"--v=0",
 		fmt.Sprintf("--cloud-provider=%s", TestCloudProvider),
 		fmt.Sprintf("--namespace=%s", TestNamespace),


### PR DESCRIPTION
this change makes the autoscaler deploy with the duplicated events flag (`--record-duplicated-events`). this change is being added because the upstream have added this flag in the 1.25 release, which allows us to drop carried functionality from the autoscaler.