### PR TITLE
[OCPCLOUD-1708]: Set default container for operator

### DIFF
--- a/install/07_deployment.yaml
+++ b/install/07_deployment.yaml
@@ -19,6 +19,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        kubectl.kubernetes.io/default-container: cluster-autoscaler-operator
       labels:
         k8s-app: cluster-autoscaler-operator
     spec:


### PR DESCRIPTION
This PR sets a default container for the cluster autoscaler operator.