### PR TITLE
Register configv1 types to schemes

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -72,6 +72,10 @@ func New(cfg *Config) (*Operator, error) {
 		return nil, fmt.Errorf("failed to register monitoring types: %v", err)
 	}
 
+	if err := configv1.AddToScheme(operator.manager.GetScheme()); err != nil {
+		return nil, fmt.Errorf("failed to register configv1 types: %v", err)
+	}
+
 	// Setup our controllers and add them to the manager.
 	if err := operator.AddControllers(); err != nil {
 		return nil, fmt.Errorf("failed to add controllers: %v", err)


### PR DESCRIPTION
This PR is an addition this PR #260, that added ignore labels for specific cloud providers. QE came across an error, where the new `configv1.Infrastructure` type was not registered to the schemes. This PR solves that issue.