### PR TITLE
Add `--expander` option for cluster-autoscaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The operator manages the following custom resources:
       --leader-elect-lease-duration=137s
       --leader-elect-renew-deadline=107s
       --leader-elect-retry-period=26s
+      --expander=random
       --expendable-pods-priority-cutoff=-10
       --max-nodes-total=24
       --cores-total=8:128

--- a/examples/clusterautoscaler.yaml
+++ b/examples/clusterautoscaler.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   logVerbosity: 1
   balanceSimilarNodeGroups: true
+  expander: "random"
   ignoreDaemonsetsUtilization: false
   skipNodesWithLocalStorage: true
   podPriorityThreshold: -10

--- a/install/01_clusterautoscaler.crd.yaml
+++ b/install/01_clusterautoscaler.crd.yaml
@@ -56,6 +56,12 @@ spec:
                 items:
                   type: string
                 type: array
+              expander:
+                description: Sets `--expander=<expander name>` CA feature flag. This feature provide
+                  strategies for selecting the node group to which new nodes will be added. 5
+                  expanders now: `random`, `most-pods`, `least-waste`, `price`, `priority`.
+                  `random` by default. 
+                type: string
               ignoreDaemonsetsUtilization:
                 description: Enables/Disables `--ignore-daemonsets-utilization` CA
                   feature flag. Should CA ignore DaemonSet pods when calculating resource

--- a/pkg/apis/autoscaling/v1/clusterautoscaler_types.go
+++ b/pkg/apis/autoscaling/v1/clusterautoscaler_types.go
@@ -16,6 +16,12 @@ type ClusterAutoscalerSpec struct {
 	// Configuration of scale down operation
 	ScaleDown *ScaleDownConfig `json:"scaleDown,omitempty"`
 
+	// Sets `--expander=<expander name>` CA feature flag. This feature provide
+	// strategies for selecting the node group to which new nodes will be added. 5
+	// expanders now: `random`, `most-pods`, `least-waste`, `price`, `priority`.
+	// `random` by default.
+	Expander string `json:"expander,omitempty"`
+
 	// Gives pods graceful termination time before scaling down
 	MaxPodGracePeriod *int32 `json:"maxPodGracePeriod,omitempty"`
 

--- a/pkg/controller/clusterautoscaler/clusterautoscaler.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler.go
@@ -67,6 +67,7 @@ const (
 	LeaderElectLeaseDurationArg      AutoscalerArg = "--leader-elect-lease-duration"
 	LeaderElectRenewDeadlineArg      AutoscalerArg = "--leader-elect-renew-deadline"
 	LeaderElectRetryPeriodArg        AutoscalerArg = "--leader-elect-retry-period"
+	ExpanderArg                      AutoscalerArg = "--expander"
 )
 
 // The following values are for cloud providers which have not yet created specific nodegroupset processors.
@@ -181,6 +182,11 @@ func AutoscalerArgs(ca *v1.ClusterAutoscaler, cfg *Config) []string {
 
 	if ca.Spec.MaxNodeProvisionTime != "" {
 		v := MaxNodeProvisionTimeArg.Value(s.MaxNodeProvisionTime)
+		args = append(args, v)
+	}
+
+	if ca.Spec.Expander != "" {
+		v := ExpanderArg.Value(s.Expander)
 		args = append(args, v)
 	}
 


### PR DESCRIPTION
Adds `--expander` option for cluster-autoscaler

Sets `--expander=<expander name>` CA feature flag. 

This feature provides strategies for selecting the node group to which new nodes will
be added. It is already supported in upstream [cluster-autoscaler](https://github.com/openshift/kubernetes-autoscaler/tree/master/cluster-autoscaler) . Here only expose it in operator.

5 expanders now: `random`, `most-pods`, `least-waste`, `price`, `priority`.
If leave without setting, use `random` by default.


Signed-off-by: Ma Xinjian <maxj.fnst@fujitsu.com>