### PR TITLE
Allow infrastructures.config.openshift.io to be listed

### DIFF
--- a/install/03_rbac.yaml
+++ b/install/03_rbac.yaml
@@ -29,6 +29,7 @@ rules:
   - create
   - get
   - update
+  - list
 - apiGroups: ["authentication.k8s.io"]
   resources:
   - tokenreviews


### PR DESCRIPTION
This PR is still associated to #260. We are encountering an error that QE posted in the JIRA card here: https://issues.redhat.com/browse/OCPCLOUD-1702

We were not able to list the object `infrastructures.config.openshift.io` as we should, since this new object was introduced in the aforementioned PR. We try to fix this issue by adding `list` verb to the `apiGroups` field for `config`.