### PR TITLE
Add infrastructures resource to config.openshift.io

### DIFF
--- a/install/03_rbac.yaml
+++ b/install/03_rbac.yaml
@@ -31,6 +31,7 @@ rules:
   - get
   - update
   - list
+  - watch
 - apiGroups: ["authentication.k8s.io"]
   resources:
   - tokenreviews

--- a/install/03_rbac.yaml
+++ b/install/03_rbac.yaml
@@ -25,6 +25,7 @@ rules:
   resources:
   - clusteroperators
   - clusteroperators/status
+  - infrastructures
   verbs:
   - create
   - get

--- a/install/03_rbac.yaml
+++ b/install/03_rbac.yaml
@@ -25,11 +25,17 @@ rules:
   resources:
   - clusteroperators
   - clusteroperators/status
-  - infrastructures
   verbs:
   - create
   - get
   - update
+  - list
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  verbs:
+  - get
   - list
   - watch
 - apiGroups: ["authentication.k8s.io"]


### PR DESCRIPTION
Fix for this story: https://issues.redhat.com/browse/OCPCLOUD-1702. QE was still running into some issue with the `Infrastructures` resource not being able to be listed in API group `config.openshift.io` at the cluster scope.