### PR TITLE
[OCPCLOUD-1814]: Update tooling in Cluster Autoscaler Operator 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,12 @@ MUTABLE_TAG ?= latest
 IMAGE        = origin-cluster-autoscaler-operator
 BUILD_IMAGE ?= registry.ci.openshift.org/openshift/release:golang-1.18
 
+# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
+ENVTEST_K8S_VERSION = 1.26
+
+PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+ENVTEST = go run ${PROJECT_DIR}/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest
+
 GOFLAGS ?= -mod=vendor
 export GOFLAGS
 GOPROXY ?=
@@ -82,7 +88,7 @@ check: fmt vet lint test ## Check your code
 
 .PHONY: test
 test: ## Run unit tests
-	$(DOCKER_CMD) go test -race -cover ./...
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(PROJECT_DIR)/bin)" ./hack/ci-test.sh
 
 .PHONY: test-e2e
 test-e2e: ## Run e2e tests

--- a/hack/ci-test.sh
+++ b/hack/ci-test.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+OPENSHIFT_CI=${OPENSHIFT_CI:-""}
+ARTIFACT_DIR=${ARTIFACT_DIR:-""}
+GINKGO=${GINKGO:-"go run ${REPO_ROOT}/vendor/github.com/onsi/ginkgo/v2/ginkgo"}
+GINKGO_ARGS=${GINKGO_ARGS:-"-v --randomize-all --randomize-suites --keep-going --race --trace --timeout=10m"}
+GINKGO_EXTRA_ARGS=${GINKGO_EXTRA_ARGS:-""}
+
+# Ensure that some home var is set and that it's not the root.
+# This is required for the kubebuilder cache.
+export HOME=${HOME:=/tmp/kubebuilder-testing}
+if [ $HOME == "/" ]; then
+  export HOME=/tmp/kubebuilder-testing
+fi
+
+if [ "$OPENSHIFT_CI" == "true" ] && [ -n "$ARTIFACT_DIR" ] && [ -d "$ARTIFACT_DIR" ]; then # detect ci environment there
+  GINKGO_ARGS="${GINKGO_ARGS} --junit-report=junit_machine_api_provider_azure.xml --cover --coverprofile=test-unit-coverage.out --output-dir=${ARTIFACT_DIR}"
+fi
+
+# Print the command we are going to run as Make would.
+echo ${GINKGO} ${GINKGO_ARGS} ${GINKGO_EXTRA_ARGS} "<omitted>"
+${GINKGO} ${GINKGO_ARGS} ${GINKGO_EXTRA_ARGS} ./pkg/... ./cmd/...
+# Capture the test result to exit on error after coverage.
+TEST_RESULT=$?
+
+if [ -f "${ARTIFACT_DIR}/test-unit-coverage.out" ]; then
+  # Convert the coverage to html for spyglass.
+  go tool cover -html=${ARTIFACT_DIR}/test-unit-coverage.out -o ${ARTIFACT_DIR}/test-unit-coverage.html
+
+  # Report the coverage at the end of the test output.
+  echo -n "Coverage "
+  go tool cover -func=${ARTIFACT_DIR}/test-unit-coverage.out | tail -n 1
+  # Blank new line after the coverage output to make it easier to read when there is an error.
+  echo
+fi
+
+# Ensure we exit based on the test result, coverage results are supplementary.
+exit ${TEST_RESULT}

--- a/tools.go
+++ b/tools.go
@@ -7,5 +7,7 @@
 package tools
 
 import (
+	_ "github.com/onsi/ginkgo/v2/ginkgo"
+	_ "sigs.k8s.io/controller-runtime/tools/setup-envtest"
 	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
 )


### PR DESCRIPTION
This commit introduces modernization of the approach to update auxiliary tooling to be more consistent such as in Control Plane Machine Set repository. We align envtest, controller-gen and other tooling as well as in the CPMS repo.