### PR TITLE
revert GPU label changes from pr 223

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The operator manages the following custom resources:
 
 - __MachineAutoscaler__: This resource targets a node group and manages
   the annotations to enable and configure autoscaling for that group,
-  e.g. the min and max size, and GPU label.  Currently only `MachineSet` objects can be
+  e.g. the min and max size.  Currently only `MachineSet` objects can be
   targeted.  ([Example][MachineAutoscaler])
 
 [ClusterAutoscaler]: https://github.com/openshift/cluster-autoscaler-operator/blob/master/examples/clusterautoscaler.yaml

--- a/pkg/controller/machineautoscaler/machineautoscaler_controller.go
+++ b/pkg/controller/machineautoscaler/machineautoscaler_controller.go
@@ -403,14 +403,9 @@ func (r *Reconciler) GetTarget(ref *corev1.ObjectReference) (*MachineTarget, err
 
 // UpdateTarget updates the min and max annotations on the given target.
 func (r *Reconciler) UpdateTarget(target *MachineTarget, min, max int) error {
-	// Update the target object's annotations and labels if necessary.
+	// Update the target object's annotations if necessary.
 	if target.NeedsUpdate(min, max) {
 		target.SetLimits(min, max)
-
-		// TODO (elmiko) remove this code path once all the infrastructure providers support adding the accelerator label
-		if target.HasGPUCapacity() && !target.HasGPUAcceleratorLabel() {
-			target.SetGPUAcceleratorLabel()
-		}
 
 		return r.client.Update(context.TODO(), target.ToUnstructured())
 	}

--- a/pkg/controller/machineautoscaler/machinetarget_test.go
+++ b/pkg/controller/machineautoscaler/machinetarget_test.go
@@ -71,30 +71,6 @@ func TestNeedsUpdate(t *testing.T) {
 	if !target.NeedsUpdate(1, 2) {
 		t.Fatal("target should need update, error parsing values")
 	}
-
-	// set the gpu capacity, and reset the min/max
-	target.SetAnnotations(map[string]string{
-		autoscalerCapacityGPU: "1",
-	})
-	target.SetLimits(4, 6)
-	if !target.NeedsUpdate(4, 6) {
-		t.Errorf("target should need update, gpu capacity with no label")
-	}
-
-	// add label
-	target.SetLabels(map[string]string{
-		autoscalerGPUAcceleratorLabel: "",
-	})
-	if target.NeedsUpdate(4, 6) {
-		t.Errorf("target should not need an update, gpu capacity with label")
-	}
-
-	// reset the gpu capacity
-	target.SetAnnotations(map[string]string{})
-	target.SetLimits(4, 6)
-	if target.NeedsUpdate(4, 6) {
-		t.Errorf("target should not need an update, no gpu capacity with label")
-	}
 }
 
 func TestSetLimits(t *testing.T) {
@@ -305,59 +281,5 @@ func TestNamespacedName(t *testing.T) {
 	if nn.Namespace != TargetNamespace {
 		t.Errorf("NamespacedName() returned bad namespace. Got: %s, Want: %s",
 			nn.Namespace, TargetNamespace)
-	}
-}
-
-func TestHasGPUCapacity(t *testing.T) {
-	target := NewTarget()
-	target.SetAnnotations(map[string]string{
-		autoscalerCapacityGPU: "1",
-	})
-
-	if !target.HasGPUCapacity() {
-		t.Error("HasGPUCapacity returned false when true was expected, 1 GPU")
-	}
-
-	target.SetAnnotations(map[string]string{
-		autoscalerCapacityGPU: "0",
-	})
-
-	if target.HasGPUCapacity() {
-		t.Error("HasGPUCapacity returned true when false was expected, 0 GPU")
-	}
-
-	target.SetAnnotations(map[string]string{
-		autoscalerCapacityGPU: "-1",
-	})
-
-	if target.HasGPUCapacity() {
-		t.Error("HasGPUCapacity returned true when false was expected, -1 GPU")
-	}
-}
-
-func TestHasGPUAcceleratorLabel(t *testing.T) {
-	target := NewTarget()
-	if target.HasGPUAcceleratorLabel() {
-		t.Error("HasGPUAcceleratorLabel return true when false was expected, no label")
-	}
-
-	target.SetLabels(map[string]string{
-		autoscalerGPUAcceleratorLabel: "",
-	})
-	if !target.HasGPUAcceleratorLabel() {
-		t.Error("HasGPUAcceleratorLabel return false when true was expected, label present")
-	}
-}
-
-func TestSetGPUAcceleratorLabel(t *testing.T) {
-	target := NewTarget()
-
-	if target.HasGPUAcceleratorLabel() {
-		t.Error("Target has GPU accelerator label when not expected")
-	}
-
-	target.SetGPUAcceleratorLabel()
-	if !target.HasGPUAcceleratorLabel() {
-		t.Error("Target does not have GPU accelerator label when expected")
 	}
 }


### PR DESCRIPTION
this change is reverting the addition of the GPU label to MachineSet objects as part of the CAO's GPU identification. It is being reverted for a few reasons: the label is added to the wrong place on the MachineSet, the label does not have the correct value, the label is not being processed by the cluster autoscaler, and we have decided to not have this bug fix automatically change values for the user.

This change does not have an impact on user experience as this value was never being processed by the cluster autoscaler and should not pose a risk to any user who is migrating older MachineSets as the label is effectively a no-op.

ref: https://github.com/openshift/cluster-autoscaler-operator/pull/223
ref: https://bugzilla.redhat.com/show_bug.cgi?id=1943194