### PR TITLE
OCPBUGS-18278: Address long acquire times during upgrade

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -48,14 +48,15 @@ func New(cfg *Config) (*Operator, error) {
 
 	// Create the controller-manager.
 	managerOptions := manager.Options{
-		Namespace:               cfg.WatchNamespace,
-		LeaderElection:          cfg.LeaderElection,
-		LeaderElectionNamespace: cfg.LeaderElectionNamespace,
-		LeaderElectionID:        cfg.LeaderElectionID,
-		LeaseDuration:           &le.LeaseDuration.Duration,
-		RenewDeadline:           &le.RenewDeadline.Duration,
-		RetryPeriod:             &le.RetryPeriod.Duration,
-		MetricsBindAddress:      fmt.Sprintf("127.0.0.1:%d", cfg.MetricsPort),
+		Namespace:                     cfg.WatchNamespace,
+		LeaderElection:                cfg.LeaderElection,
+		LeaderElectionNamespace:       cfg.LeaderElectionNamespace,
+		LeaderElectionID:              cfg.LeaderElectionID,
+		LeaderElectionReleaseOnCancel: true,
+		LeaseDuration:                 &le.LeaseDuration.Duration,
+		RenewDeadline:                 &le.RenewDeadline.Duration,
+		RetryPeriod:                   &le.RetryPeriod.Duration,
+		MetricsBindAddress:            fmt.Sprintf("127.0.0.1:%d", cfg.MetricsPort),
 	}
 
 	operator.manager, err = manager.New(clientConfig, managerOptions)


### PR DESCRIPTION
The upgrade of cluster-autoscaler-operator the  was delayed significantly by lease acquire times, so we add flag `LeaderElectionReleaseOnCancel: true` to the `manager.Options` struct to make sure that when the manager gets shutdown, the leader steps down voluntarily. 

In order to set this condition, we need to make sure that the binary is stopped immediately when the manager is stopped, which in this case should be ok (discussed with @elmiko). 

The outcome for this change is that leader transitions are much quicker as the new leader doesn't have to wait for `LeaseDuration` time.