### PR TITLE
OCPBUGS-18137: Provide the architecture of the control plane as argument to --scale-up-from-zero-default-arch

### DIFF
--- a/pkg/controller/clusterautoscaler/clusterautoscaler.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler.go
@@ -2,6 +2,7 @@ package clusterautoscaler
 
 import (
 	"fmt"
+	"runtime"
 
 	configv1 "github.com/openshift/api/config/v1"
 	v1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1"
@@ -67,6 +68,7 @@ const (
 	LeaderElectLeaseDurationArg      AutoscalerArg = "--leader-elect-lease-duration"
 	LeaderElectRenewDeadlineArg      AutoscalerArg = "--leader-elect-renew-deadline"
 	LeaderElectRetryPeriodArg        AutoscalerArg = "--leader-elect-retry-period"
+	ScaleUpFromZeroDefaultArch       AutoscalerArg = "--scale-up-from-zero-default-arch"
 )
 
 // The following values are for cloud providers which have not yet created specific nodegroupset processors.
@@ -192,6 +194,7 @@ func AutoscalerArgs(ca *v1.ClusterAutoscaler, cfg *Config) []string {
 		LeaderElectLeaseDurationArg.Value(leaderElectLeaseDuration),
 		LeaderElectRenewDeadlineArg.Value(leaderElectRenewDeadline),
 		LeaderElectRetryPeriodArg.Value(leaderElectRetryPeriod),
+		ScaleUpFromZeroDefaultArch.Value(runtime.GOARCH),
 	}
 
 	if ca.Spec.MaxPodGracePeriod != nil {


### PR DESCRIPTION
Depends on https://github.com/openshift/kubernetes-autoscaler/pull/261

When autoscale from zero is enabled in non-amd64 single-arch clusters on cloud providers managed by actuators that do not set the architecture in the capacity annotations (ref. [MIXEDARCH-129](https://issues.redhat.com//browse/MIXEDARCH-129)), passing the argument --scale-up-from-zero-default-arch will allow not to default on the amd64 architecture for building the generic labels to scale out nodegroups from zero.

This commit sets the argument for the cluster-autoscaler to runtime.GOARCH.

/hold