### PR TITLE
OCPBUGS-19411: cluster-autoscaler-operator: clusterrole add clusteroperators watch

### DIFF
--- a/install/03_rbac.yaml
+++ b/install/03_rbac.yaml
@@ -30,6 +30,7 @@ rules:
   - get
   - update
   - list
+  - watch
 - apiGroups:
   - config.openshift.io
   resources:


### PR DESCRIPTION
Add missing `watch` verb for `clusteroperators` to the `cluster-autoscaler-operator` clusterrole.