### PR TITLE
MIXEDARCH-429: Add the environment variable value for CAPI_SCALE_ZERO_DEFAULT_ARCH

### DIFF
--- a/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
@@ -3,6 +3,7 @@ package clusterautoscaler
 import (
 	"context"
 	"fmt"
+	goruntime "runtime"
 
 	configv1 "github.com/openshift/api/config/v1"
 	autoscalingv1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1"
@@ -31,14 +32,15 @@ import (
 )
 
 const (
-	controllerName      = "cluster_autoscaler_controller"
-	caServiceAccount    = "cluster-autoscaler"
-	caPriorityClassName = "system-cluster-critical"
-	CAPIGroupEnvVar     = "CAPI_GROUP"
-	CAPIGroup           = "machine.openshift.io"
-	CAPIVersionEnvVar   = "CAPI_VERSION"
-	CAPIVersion         = "v1beta1"
-	infrastructureName  = "cluster"
+	controllerName                 = "cluster_autoscaler_controller"
+	caServiceAccount               = "cluster-autoscaler"
+	caPriorityClassName            = "system-cluster-critical"
+	CAPIGroupEnvVar                = "CAPI_GROUP"
+	CAPIGroup                      = "machine.openshift.io"
+	CAPIScaleZeroDefaultArchEnvVar = "CAPI_SCALE_ZERO_DEFAULT_ARCH"
+	CAPIVersionEnvVar              = "CAPI_VERSION"
+	CAPIVersion                    = "v1beta1"
+	infrastructureName             = "cluster"
 )
 
 // NewReconciler returns a new Reconciler.
@@ -444,6 +446,10 @@ func (r *Reconciler) AutoscalerPodSpec(ca *autoscalingv1.ClusterAutoscaler) *cor
 					{
 						Name:  CAPIVersionEnvVar,
 						Value: CAPIVersion,
+					},
+					{
+						Name:  CAPIScaleZeroDefaultArchEnvVar,
+						Value: goruntime.GOARCH,
 					},
 				},
 				Resources: corev1.ResourceRequirements{


### PR DESCRIPTION
kubernetes/autoscaler#6066 merged using an env var instead of the command line argument, we decided to go with downstream in openshift/kubernetes-autoscaler#261. We will need to be ready for onboarding that change during the next rebase. 

This PR adds the env var to the deployment of the autscaler: we could merge this and prepare another revert PR for 6b7a17780f92775d4e08b9a594b7f1a29a75f7e8 or do both of them at once, during the next rebase. Wdyt @elmiko ?

Refers #284 