### PR TITLE
MIXEDARCH-429: Revert "OCPBUGS-18137: Provide the architecture of the control plane as argument to --scale-up-from-zero-default-arch"

### DIFF
--- a/pkg/controller/clusterautoscaler/clusterautoscaler.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler.go
@@ -2,7 +2,6 @@ package clusterautoscaler
 
 import (
 	"fmt"
-	"runtime"
 
 	configv1 "github.com/openshift/api/config/v1"
 	v1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1"
@@ -68,7 +67,6 @@ const (
 	LeaderElectLeaseDurationArg      AutoscalerArg = "--leader-elect-lease-duration"
 	LeaderElectRenewDeadlineArg      AutoscalerArg = "--leader-elect-renew-deadline"
 	LeaderElectRetryPeriodArg        AutoscalerArg = "--leader-elect-retry-period"
-	ScaleUpFromZeroDefaultArch       AutoscalerArg = "--scale-up-from-zero-default-arch"
 )
 
 // The following values are for cloud providers which have not yet created specific nodegroupset processors.
@@ -194,7 +192,6 @@ func AutoscalerArgs(ca *v1.ClusterAutoscaler, cfg *Config) []string {
 		LeaderElectLeaseDurationArg.Value(leaderElectLeaseDuration),
 		LeaderElectRenewDeadlineArg.Value(leaderElectRenewDeadline),
 		LeaderElectRetryPeriodArg.Value(leaderElectRetryPeriod),
-		ScaleUpFromZeroDefaultArch.Value(runtime.GOARCH),
 	}
 
 	if ca.Spec.MaxPodGracePeriod != nil {


### PR DESCRIPTION
The rebase of the autoscaler to 1.29 will downstream the changes in kubernetes/autoscaler#6066 and drop the changes in https://github.com/openshift/kubernetes-autoscaler/pull/261, leading to a failure in the deployment of the autoscaler because of the unrecognized command-line argument (if I'm not wrong).

The rebase of the autoscaler should include the commit in https://github.com/elmiko/kubernetes-autoscaler/commit/2120c26a5116f9c3a3ed752bd041d28b3109aa2a to be dropped on the next rebase and after this PR merge.

This PR reverts openshift/cluster-autoscaler-operator#284 and should be merged after the kubernetes-autoscaler repo is rebased to 1.29. 