### PR TITLE
OCPBUGS-28230: add FallbackToLogsOnError for easier debugging

### DIFF
--- a/install/07_deployment.yaml
+++ b/install/07_deployment.yaml
@@ -44,7 +44,7 @@ spec:
           name: metrics
           protocol: TCP
         terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        terminationMessagePolicy: FallbackToLogsOnError
         resources:
           requests:
             memory: 20Mi


### PR DESCRIPTION
All openshift operators must include FallbackToLogsOnError to ease debugging.