### PR TITLE
OCPBUGS-28207: update min/max memory limit documentation

### DIFF
--- a/install/01_clusterautoscaler.crd.yaml
+++ b/install/01_clusterautoscaler.crd.yaml
@@ -141,9 +141,9 @@ spec:
                     minimum: 0
                     type: integer
                   memory:
-                    description: Minimum and maximum number of gigabytes of memory
-                      in cluster, in the format <min>:<max>. Cluster autoscaler will
-                      not scale the cluster beyond these numbers.
+                    description: Minimum and maximum number of GiB of memory in cluster,
+                      in the format <min>:<max>. Cluster autoscaler will not scale
+                      the cluster beyond these numbers.
                     properties:
                       max:
                         format: int32

--- a/pkg/apis/autoscaling/v1/clusterautoscaler_types.go
+++ b/pkg/apis/autoscaling/v1/clusterautoscaler_types.go
@@ -97,7 +97,7 @@ type ResourceLimits struct {
 	// Cluster autoscaler will not scale the cluster beyond these numbers.
 	Cores *ResourceRange `json:"cores,omitempty"`
 
-	// Minimum and maximum number of gigabytes of memory in cluster, in the format <min>:<max>.
+	// Minimum and maximum number of GiB of memory in cluster, in the format <min>:<max>.
 	// Cluster autoscaler will not scale the cluster beyond these numbers.
 	Memory *ResourceRange `json:"memory,omitempty"`
 


### PR DESCRIPTION
This change makes the documentation more accurate by switching from "gigabytes" to "GiB", the old value was incorrect.