### PR TITLE
AUTH-482: set required-scc for openshift workloads

### DIFF
--- a/install/07_deployment.yaml
+++ b/install/07_deployment.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         kubectl.kubernetes.io/default-container: cluster-autoscaler-operator
+        openshift.io/required-scc: restricted-v2
       labels:
         k8s-app: cluster-autoscaler-operator
     spec:


### PR DESCRIPTION
References:
- [SCC docs](https://docs.openshift.com/container-platform/4.15/authentication/managing-security-context-constraints.html)
- [SCC pinning docs](https://docs.openshift.com/container-platform/4.15/authentication/managing-security-context-constraints.html#security-context-constraints-requiring_configuring-internal-oauth)