### PR TITLE
OCPBUGS-42132: set max soft bulk taint count to zero

### DIFF
--- a/pkg/controller/clusterautoscaler/clusterautoscaler.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler.go
@@ -15,6 +15,12 @@ const (
 	leaderElectLeaseDuration = "137s"
 	leaderElectRenewDeadline = "107s"
 	leaderElectRetryPeriod   = "26s"
+
+	// The max bulk soft taint count is the maximum number of empty nodes that can be soft tainted for
+	// deletion at once. A value of zero disables the bulk soft tainting behavior. This option is being
+	// added to remediate a bad interaction between the bulk delete logic and the cluster-api provider,
+	// for more information see https://issues.redhat.com/browse/OCPBUGS-42132
+	maxBulkSoftTaintCount = "0"
 )
 
 // AutoscalerArg represents a command line argument to the cluster-autoscaler
@@ -71,6 +77,7 @@ const (
 	LeaderElectRetryPeriodArg        AutoscalerArg = "--leader-elect-retry-period"
 	ScaleUpFromZeroDefaultArch       AutoscalerArg = "--scale-up-from-zero-default-arch"
 	ExpanderArg                      AutoscalerArg = "--expander"
+	MaxBulkSoftTaintCountArg         AutoscalerArg = "--max-bulk-soft-taint-count"
 )
 
 // Constants for the command line expander flags
@@ -199,6 +206,7 @@ func AutoscalerArgs(ca *v1.ClusterAutoscaler, cfg *Config) []string {
 		LeaderElectLeaseDurationArg.Value(leaderElectLeaseDuration),
 		LeaderElectRenewDeadlineArg.Value(leaderElectRenewDeadline),
 		LeaderElectRetryPeriodArg.Value(leaderElectRetryPeriod),
+		MaxBulkSoftTaintCountArg.Value(maxBulkSoftTaintCount),
 	}
 
 	if ca.Spec.MaxPodGracePeriod != nil {


### PR DESCRIPTION
This change disables the maximum number of nodes that can be soft tainted or untainted at once for deletion.