### PR TITLE
OCPBUGS-57041: update cluster provider type early

### DIFF
--- a/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
+++ b/pkg/controller/clusterautoscaler/clusterautoscaler_controller.go
@@ -217,6 +217,15 @@ func (r *Reconciler) Reconcile(_ context.Context, request reconcile.Request) (re
 		return reconcile.Result{}, nil
 	}
 
+	// Update the cluster provider type.
+	if r.config.platformType == "" {
+		platformType, err := r.getPlatformType()
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		r.config.platformType = platformType
+	}
+
 	if err := r.ensureAutoscalerMonitoring(ca); err != nil {
 		errMsg := fmt.Sprintf("Error ensuring ClusterAutoscaler monitoring: %v", err)
 		r.recorder.Event(caRef, corev1.EventTypeWarning, "FailedCreate", errMsg)
@@ -302,13 +311,6 @@ func (r *Reconciler) UpdateAutoscaler(ca *autoscalingv1.ClusterAutoscaler) error
 	if err != nil {
 		return err
 	}
-
-	// Update the cluster provider type.
-	platformType, err := r.getPlatformType()
-	if err != nil {
-		return err
-	}
-	r.config.platformType = platformType
 
 	existingSpec := existingDeployment.Spec.Template.Spec
 	expectedSpec := r.AutoscalerPodSpec(ca)


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-57041

This bug was happening because the platform type of the cluster was not updated before CreateAutoscaler is being called. This results in some arguments not getting added to the deployment spec initially, but during a subsequent quick reconcile, the platform type is updated in the UpdateAutoscaler function. So immediately, the args are now added to the deployment, which triggers a new pod(s) rollout.