### PR TITLE
OCPBUGS-111092: update version to properly detect errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,15 @@ DBG         ?= 0
 PROJECT     ?= cluster-autoscaler-operator
 ORG_PATH    ?= github.com/openshift
 REPO_PATH   ?= $(ORG_PATH)/$(PROJECT)
-VERSION     ?= $(shell git describe --always --dirty --abbrev=7)
+# if VERSION is defined use that, otherwise make sure we have a semver-like version (added in response to OCPBUGS-111092)
+ifeq ($(origin VERSION), undefined)
+	tmpVersion = $(shell git describe --always --dirty --abbrev=7)
+	ifeq ($(shell echo $(tmpVersion) | grep "^v\{0,1\}[0-9]\+\.[0-9]\+\.[0-9]\+"; echo $$?), 0)
+		VERSION = $(tmpVersion)
+	else
+		VERSION = v0.0.0-$(tmpVersion)
+	endif
+endif
 LD_FLAGS    ?= -X $(REPO_PATH)/pkg/version.Raw=$(VERSION)
 BUILD_DEST  ?= bin/cluster-autoscaler-operator
 MUTABLE_TAG ?= latest

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2026 Red Hat, Inc.
+ *
+ */
 package version
 
 import (
@@ -7,14 +23,34 @@ import (
 	"github.com/blang/semver/v4"
 )
 
+const (
+	errorVersion = "0.0.0-unable-to-set-version"
+)
+
 var (
 	// Raw is the string representation of the version. This will be replaced
 	// with the calculated version at build time.
-	Raw = "v0.0.0-was-not-built-properly"
+	Raw = "0.0.0-version-not-set"
 
 	// Version is semver representation of the version.
-	Version = semver.MustParse(strings.TrimLeft(Raw, "v"))
+	Version = mustParse(Raw)
 
 	// String is the human-friendly representation of the version.
-	String = fmt.Sprintf("cluster-autoscaler-operator %s", Raw)
+	String = fmt.Sprintf("cluster-autoscaler-operator %s", Version)
 )
+
+func mustParse(v string) semver.Version {
+	if version, err := semver.Parse(strings.TrimLeft(v, "v")); err != nil {
+		// version did not parse cleanly, append it to the zero value
+		appendedVersion, err := semver.Parse(fmt.Sprintf("0.0.0-%s", v))
+		if err != nil {
+			// still having an issue making a clean version, use a known value
+			// this shouldn't happen in practice
+			return semver.MustParse(errorVersion)
+		} else {
+			return appendedVersion
+		}
+	} else {
+		return version
+	}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -47,9 +47,9 @@ func mustParse(v string) semver.Version {
 			// still having an issue making a clean version, use a known value
 			// this shouldn't happen in practice
 			return semver.MustParse(errorVersion)
-		} else {
-			return appendedVersion
 		}
+
+		return appendedVersion
 	} else {
 		return version
 	}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2026 Red Hat, Inc.
+ *
+ */
+package version
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+)
+
+func TestMustParse(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected semver.Version
+	}{
+		{
+			name:     "v0.0.0 parses properly",
+			input:    "v0.0.0",
+			expected: semver.MustParse("0.0.0"),
+		},
+		{
+			name:     "abbreviated commit hash returns concatenated version",
+			input:    "abcdef",
+			expected: semver.MustParse("0.0.0-abcdef"),
+		},
+		{
+			name:     "malformed returns well known error",
+			input:    "",
+			expected: semver.MustParse(errorVersion),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			observed := mustParse(tc.input)
+			if !observed.Equals(tc.expected) {
+				t.Errorf("versions do not match, expected %q, observed %q", tc.expected, observed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change is being proposed to fix a condition where a malformed version string during build time can result in a panic during execution time. The CAO will now interrogate the compiled version to ensure that it won't panic during execution, and update the displayed version accordingly.

In cases where the version follows semver, it will use that version. If the version string does not adhere to semver, then the version will be `0.0.0-<version string>`. If the version string produces errors then the version will be reported as `0.0.0-unable-to-set-version`.